### PR TITLE
fix: Make logo always visible on blue sidebar backgrounds

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -163,10 +163,10 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     <SidebarProvider>
       <Sidebar>
         <SidebarHeader>
-          <Link href="/admin" passHref className="flex items-center gap-2">
-            <Logo />
+          <div className="flex items-center gap-2">
+            <Logo linkTo="/admin" forceLight />
             <Badge variant="destructive" className="text-xs">Admin</Badge>
-          </Link>
+          </div>
         </SidebarHeader>
         <AdminSidebarNav onSignOutClick={() => setShowLogoutDialog(true)} />
       </Sidebar>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -197,7 +197,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     <SidebarProvider>
       <Sidebar>
         <SidebarHeader>
-          <Link href="/" passHref><Logo /></Link>
+          <Logo linkTo="/" forceLight />
         </SidebarHeader>
         <SidebarNav onSignOutClick={() => setShowLogoutDialog(true)} isAdmin={isAdmin} />
       </Sidebar>

--- a/src/app/driver-dashboard/layout.tsx
+++ b/src/app/driver-dashboard/layout.tsx
@@ -186,9 +186,7 @@ export default function DriverDashboardLayout({
     <SidebarProvider>
       <Sidebar>
         <SidebarHeader>
-          <Link href="/" passHref>
-            <Logo />
-          </Link>
+          <Logo linkTo="/" forceLight />
         </SidebarHeader>
         <SidebarNav onSignOutClick={() => setShowLogoutDialog(true)} />
       </Sidebar>

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 
 // Inline SVG components for theme-adaptive coloring
-function LogoFull({ className }: { className?: string }) {
+function LogoFull({ className, forceLight }: { className?: string; forceLight?: boolean }) {
+  const textFill = forceLight ? "fill-white" : "fill-gray-900 dark:fill-white";
   return (
     <svg
       viewBox="0 0 1200 250"
@@ -15,17 +16,18 @@ function LogoFull({ className }: { className?: string }) {
         {/* Blue top chevron - brand color */}
         <path d="M115 110 L20 15 L55 15 L115 75 L175 15 L210 15 L115 110 Z" fill="#1E9BD7"/>
         {/* Bottom chevron - adapts to theme */}
-        <path d="M115 130 L20 225 L55 225 L115 165 L175 225 L210 225 L115 130 Z" className="fill-gray-900 dark:fill-white"/>
+        <path d="M115 130 L20 225 L55 225 L115 165 L175 225 L210 225 L115 130 Z" className={textFill}/>
       </g>
       {/* "traFleet" text - adapts to theme */}
-      <text x="220" y="170" fontFamily="Arial, Helvetica, sans-serif" fontSize="140" fontWeight="700" className="fill-gray-900 dark:fill-white" letterSpacing="-3">
+      <text x="220" y="170" fontFamily="Arial, Helvetica, sans-serif" fontSize="140" fontWeight="700" className={textFill} letterSpacing="-3">
         traFleet
       </text>
     </svg>
   );
 }
 
-function LogoIcon({ className }: { className?: string }) {
+function LogoIcon({ className, forceLight }: { className?: string; forceLight?: boolean }) {
+  const textFill = forceLight ? "fill-white" : "fill-gray-900 dark:fill-white";
   return (
     <svg
       viewBox="0 0 800 800"
@@ -37,7 +39,7 @@ function LogoIcon({ className }: { className?: string }) {
       {/* Blue top chevron - brand color */}
       <path d="M400 380 L100 80 L180 80 L400 300 L620 80 L700 80 L400 380 Z" fill="#1E9BD7"/>
       {/* Bottom chevron - adapts to theme */}
-      <path d="M400 420 L100 720 L180 720 L400 500 L620 720 L700 720 L400 420 Z" className="fill-gray-900 dark:fill-white"/>
+      <path d="M400 420 L100 720 L180 720 L400 500 L620 720 L700 720 L400 420 Z" className={textFill}/>
     </svg>
   );
 }
@@ -45,11 +47,13 @@ function LogoIcon({ className }: { className?: string }) {
 export function Logo({
   className,
   variant = "full",
-  linkTo = "/"
+  linkTo = "/",
+  forceLight = false
 }: {
   className?: string;
   variant?: "full" | "icon";
   linkTo?: string;
+  forceLight?: boolean;
 }) {
   const content = (
     <div
@@ -59,9 +63,9 @@ export function Logo({
       )}
     >
       {variant === "full" ? (
-        <LogoFull className="h-10 w-auto" />
+        <LogoFull className="h-10 w-auto" forceLight={forceLight} />
       ) : (
-        <LogoIcon className="h-10 w-10" />
+        <LogoIcon className="h-10 w-10" forceLight={forceLight} />
       )}
     </div>
   );


### PR DESCRIPTION
Added forceLight prop to Logo component for use in sidebars where the background is always dark/blue regardless of light/dark mode theme.