### PR TITLE
feat: Equipment matching as hard filter with multi-trailer support

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,3 +1,5 @@
+import type { TrailerType } from './trailer-types';
+
 export type Review = {
   id: string;
   reviewer: string;
@@ -13,7 +15,8 @@ export type Driver = {
   location: string;
   certifications: string[];
   availability: "Available" | "On-trip" | "Off-duty";
-  vehicleType: "Dry Van" | "Reefer" | "Flatbed";
+  vehicleType: "Dry Van" | "Reefer" | "Flatbed"; // Legacy - single type
+  trailerTypes?: TrailerType[]; // New - array of types driver can haul
   profileSummary?: string;
   ownerId?: string;
   isActive?: boolean;
@@ -45,6 +48,7 @@ export type Load = {
   weight: number;
   status: "Pending" | "Matched" | "In-transit" | "Delivered";
   requiredQualifications: string[];
+  trailerType?: TrailerType; // New - standardized trailer type
   description?: string;
   ownerId?: string;
   price?: number;


### PR DESCRIPTION
- Equipment compatibility is now a HARD FILTER (incompatible drivers/loads don't appear)
- Drivers can select multiple trailer types they can haul (checkboxes)
- Loads select one required trailer type (dropdown)
- Added trailerTypes array field to Driver type
- Added trailerType field to Load type
- Updated matching algorithm to filter by equipment first, then rank by location
- API now properly saves trailerType field for loads
- Driver profile UI updated with multi-select checkboxes for trailer types