### PR TITLE
fix: Improve mobile responsiveness across app

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -202,14 +202,14 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <SidebarNav onSignOutClick={() => setShowLogoutDialog(true)} isAdmin={isAdmin} />
       </Sidebar>
       <SidebarInset>
-        <header className="flex h-14 items-center justify-between border-b bg-background px-4">
+        <header className="flex h-12 md:h-14 items-center justify-between border-b bg-background px-3 md:px-4">
           <SidebarTrigger className="md:hidden" />
           <div className="ml-auto flex items-center gap-2">
             <ThemeToggle />
-            <div className="text-sm text-muted-foreground">{user?.email}</div>
+            <div className="text-xs md:text-sm text-muted-foreground hidden sm:block truncate max-w-[150px] md:max-w-none">{user?.email}</div>
           </div>
         </header>
-        <main className="flex-1 overflow-auto p-4 md:p-6">{children}</main>
+        <main className="flex-1 overflow-auto p-3 md:p-6">{children}</main>
         <Footer />
       </SidebarInset>
       

--- a/src/app/dashboard/matches/page.tsx
+++ b/src/app/dashboard/matches/page.tsx
@@ -255,18 +255,18 @@ export default function MatchesPage() {
 
   return (
     <TooltipProvider>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-[calc(100vh-8rem)]">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 lg:h-[calc(100vh-8rem)]">
         {/* MY ASSETS - Loads and Drivers I own */}
-        <Card className="flex flex-col h-full overflow-hidden">
-            <CardHeader className="flex-shrink-0">
-              <CardTitle className="font-headline flex items-center gap-2">
-                <Briefcase className="h-5 w-5" /> My Assets
+        <Card className="flex flex-col h-[50vh] lg:h-full overflow-hidden">
+            <CardHeader className="flex-shrink-0 p-4 md:p-6">
+              <CardTitle className="font-headline flex items-center gap-2 text-base md:text-lg">
+                <Briefcase className="h-4 w-4 md:h-5 md:w-5" /> My Assets
               </CardTitle>
-              <CardDescription>Select your load or driver to find matches.</CardDescription>
+              <CardDescription className="text-xs md:text-sm">Select your load or driver to find matches.</CardDescription>
             </CardHeader>
             <CardContent className="p-0 flex-1 overflow-hidden">
               <ScrollArea className="h-full">
-                <div className="p-6 pt-0">
+                <div className="p-3 md:p-6 pt-0">
                   {/* My Pending Loads Section */}
                   <div className="mb-4">
                     <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-2 mb-2">
@@ -355,12 +355,12 @@ export default function MatchesPage() {
           </Card>
 
         {/* Ranked Matches Panel */}
-        <Card className="flex flex-col h-full overflow-hidden">
-          <CardHeader className="flex-shrink-0">
-            <CardTitle className="font-headline flex items-center gap-2">
-              <Link2 className="h-5 w-5" /> Ranked Matches
+        <Card className="flex flex-col h-[50vh] lg:h-full overflow-hidden">
+          <CardHeader className="flex-shrink-0 p-4 md:p-6">
+            <CardTitle className="font-headline flex items-center gap-2 text-base md:text-lg">
+              <Link2 className="h-4 w-4 md:h-5 md:w-5" /> Ranked Matches
             </CardTitle>
-            <CardDescription className="truncate">
+            <CardDescription className="truncate text-xs md:text-sm">
               {selectionMode === 'load' && selectedLoad
                 ? `Top drivers for your load to ${selectedLoad.destination}`
                 : selectionMode === 'driver' && selectedMyDriver
@@ -370,7 +370,7 @@ export default function MatchesPage() {
           </CardHeader>
           <CardContent className="flex-1 overflow-hidden p-0">
             <ScrollArea className="h-full">
-              <div className="p-6 pt-0">
+              <div className="p-3 md:p-6 pt-0">
                 {/* Load Owner Mode: Show driver matches */}
                 {selectionMode === 'load' && selectedLoad ? (
                   driverMatches.length > 0 ? (

--- a/src/components/driver-match-request-modal.tsx
+++ b/src/components/driver-match-request-modal.tsx
@@ -213,18 +213,18 @@ export function DriverMatchRequestModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <User className="h-5 w-5" />
+          <DialogTitle className="flex items-center gap-2 text-base md:text-lg">
+            <User className="h-4 w-4 md:h-5 md:w-5" />
             Offer Your Driver
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="text-xs md:text-sm">
             Offer your driver for this load. The load owner has 48 hours to respond.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
+        <div className="space-y-3 md:space-y-4 py-2 md:py-4">
           {/* Driver Summary */}
-          <div className="p-4 bg-muted/50 rounded-lg">
+          <div className="p-3 md:p-4 bg-muted/50 rounded-lg">
             <h4 className="font-medium mb-2">Your Driver</h4>
             <div className="flex items-start justify-between">
               <div className="flex-1">

--- a/src/components/edit-driver-modal.tsx
+++ b/src/components/edit-driver-modal.tsx
@@ -172,10 +172,10 @@ export function EditDriverModal({ open, onOpenChange, driver, onSuccess }: EditD
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="font-headline">Edit Driver Profile</DialogTitle>
-          <DialogDescription>
+          <DialogTitle className="font-headline text-base md:text-lg">Edit Driver Profile</DialogTitle>
+          <DialogDescription className="text-xs md:text-sm">
             Update any fields below. You can save incomplete forms and finish later.
           </DialogDescription>
         </DialogHeader>
@@ -183,12 +183,12 @@ export function EditDriverModal({ open, onOpenChange, driver, onSuccess }: EditD
         <form onSubmit={handleSubmit}>
           <Tabs defaultValue="basic" className="w-full">
             <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="basic">Basic Info</TabsTrigger>
-              <TabsTrigger value="compliance">Compliance</TabsTrigger>
+              <TabsTrigger value="basic" className="text-xs md:text-sm">Basic Info</TabsTrigger>
+              <TabsTrigger value="compliance" className="text-xs md:text-sm">Compliance</TabsTrigger>
             </TabsList>
 
-            <TabsContent value="basic" className="space-y-4 pt-4">
-              <div className="grid grid-cols-2 gap-4">
+            <TabsContent value="basic" className="space-y-3 md:space-y-4 pt-3 md:pt-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="edit-name">Full Name</Label>
                   <Input
@@ -208,9 +208,9 @@ export function EditDriverModal({ open, onOpenChange, driver, onSuccess }: EditD
                 </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="edit-email">Email</Label>
+                  <Label htmlFor="edit-email" className="text-sm">Email</Label>
                   <Input
                     id="edit-email"
                     type="email"

--- a/src/components/match-request-modal.tsx
+++ b/src/components/match-request-modal.tsx
@@ -204,18 +204,18 @@ export function MatchRequestModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Truck className="h-5 w-5" />
+          <DialogTitle className="flex items-center gap-2 text-base md:text-lg">
+            <Truck className="h-4 w-4 md:h-5 md:w-5" />
             Send Match Request
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="text-xs md:text-sm">
             Request this driver for your load. The driver owner has 48 hours to respond.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
+        <div className="space-y-3 md:space-y-4 py-2 md:py-4">
           {/* Load Summary */}
-          <div className="p-4 bg-muted/50 rounded-lg">
+          <div className="p-3 md:p-4 bg-muted/50 rounded-lg">
             <h4 className="font-medium mb-2">Load Details</h4>
             <p className="text-sm font-semibold">
               {load.origin} → {load.destination}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[92vw] sm:w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 md:gap-4 border bg-background p-4 md:p-6 shadow-lg duration-200 max-h-[90vh] overflow-y-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-3 top-3 md:right-4 md:top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -73,7 +73,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2",
       className
     )}
     {...props}


### PR DESCRIPTION
- Matches page: responsive grid (50vh cards on mobile, full height on desktop)
- Dialog component: 92vw width on mobile, max-h-90vh with scroll, responsive padding
- Dashboard header: hide email on mobile, smaller height (h-12 vs h-14)
- Edit driver modal: responsive 2xl max-width, single column on mobile
- Match modals: responsive text and spacing
- Responsive padding throughout (p-3 mobile, p-6 desktop)
- Responsive text sizes (text-xs/base mobile, text-sm/lg desktop)