### PR TITLE
chore: grant-admin script for setting isAdmin + adminRole on QA/prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "grant-admin:qa": "GOOGLE_CLOUD_PROJECT=xtrafleet-qa npx tsx scripts/grant-admin.ts",
+    "grant-admin:prod": "GOOGLE_CLOUD_PROJECT=studio-5112915880-e9ca2 npx tsx scripts/grant-admin.ts",
     "predeploy": "./scripts/pre-deploy.sh",
     "deploy": "./scripts/deploy.sh",
     "deploy:hosting": "npm run build && firebase deploy --only hosting",

--- a/scripts/grant-admin.ts
+++ b/scripts/grant-admin.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Grant XtraFleet admin role to an existing user by email.
+ *
+ * Looks up the Firebase Auth user by email, then writes
+ *   isAdmin: true
+ *   adminRole: <role>           (default: 'super_admin')
+ * onto owner_operators/{uid}, merging with existing fields. The admin layout
+ * (src/app/admin/layout.tsx) reads from owner_operators, so this is the
+ * doc that actually gates admin UI access.
+ *
+ * Usage (from repo root):
+ *
+ *   firebase use qa
+ *   GOOGLE_CLOUD_PROJECT=xtrafleet-qa npx tsx scripts/grant-admin.ts edward@xtrafleet.com
+ *
+ * Or to grant a non-super role:
+ *
+ *   npx tsx scripts/grant-admin.ts edward@xtrafleet.com admin
+ *   npx tsx scripts/grant-admin.ts edward@xtrafleet.com support
+ *   npx tsx scripts/grant-admin.ts edward@xtrafleet.com billing_admin
+ *
+ * Authentication: uses Application Default Credentials. If you don't have
+ * them set up, run once:
+ *
+ *   gcloud auth application-default login
+ *   gcloud config set project xtrafleet-qa
+ *
+ * Or set GOOGLE_APPLICATION_CREDENTIALS to a service-account JSON key path.
+ */
+
+import admin from 'firebase-admin';
+
+type AdminRole = 'super_admin' | 'admin' | 'support' | 'billing_admin';
+const VALID_ROLES: AdminRole[] = ['super_admin', 'admin', 'support', 'billing_admin'];
+
+async function main() {
+  const [, , email, roleArg = 'super_admin'] = process.argv;
+
+  if (!email) {
+    console.error('Usage: npx tsx scripts/grant-admin.ts <email> [role]');
+    console.error(`  role: one of ${VALID_ROLES.join(', ')} (default: super_admin)`);
+    process.exit(1);
+  }
+
+  if (!VALID_ROLES.includes(roleArg as AdminRole)) {
+    console.error(`Invalid role "${roleArg}". Must be one of: ${VALID_ROLES.join(', ')}`);
+    process.exit(1);
+  }
+  const role = roleArg as AdminRole;
+
+  const projectId =
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    process.env.GCLOUD_PROJECT ||
+    process.env.FIREBASE_CONFIG_PROJECT_ID;
+
+  if (!projectId) {
+    console.error('No project id detected. Set GOOGLE_CLOUD_PROJECT, e.g.:');
+    console.error('  GOOGLE_CLOUD_PROJECT=xtrafleet-qa npx tsx scripts/grant-admin.ts <email>');
+    process.exit(1);
+  }
+
+  console.log(`📡 Connecting to Firebase project: ${projectId}`);
+  admin.initializeApp({ projectId });
+
+  let user: admin.auth.UserRecord;
+  try {
+    user = await admin.auth().getUserByEmail(email);
+  } catch (err) {
+    console.error(`❌ No Firebase Auth user found for ${email} in project ${projectId}.`);
+    console.error('  Make sure you ran "firebase use qa" (or set GOOGLE_CLOUD_PROJECT) and the user has signed up on QA.');
+    if (err instanceof Error) console.error(`  ${err.message}`);
+    process.exit(1);
+  }
+
+  console.log(`✓ Found auth user: ${user.uid}`);
+
+  const docRef = admin.firestore().collection('owner_operators').doc(user.uid);
+  const before = await docRef.get();
+  if (!before.exists) {
+    console.warn(`⚠ owner_operators/${user.uid} doesn't exist yet — creating with admin fields.`);
+    console.warn('  This is unusual; normally the doc is created during signup.');
+  }
+
+  await docRef.set(
+    {
+      isAdmin: true,
+      adminRole: role,
+      adminGrantedAt: new Date().toISOString(),
+      adminGrantedBy: 'scripts/grant-admin.ts',
+    },
+    { merge: true },
+  );
+
+  console.log(`✓ Granted ${role} on owner_operators/${user.uid} (${email}).`);
+  console.log('  Refresh the QA dashboard — the admin sidebar should appear.');
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Unhandled error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
One-off Node script + npm shortcuts so we don't have to hand-edit Firestore docs to grant admin access. Looks up the Firebase Auth user by email, then merges `isAdmin: true` + `adminRole` onto `owner_operators/{uid}` — the doc the admin layout actually reads.

Motivated by the QA admin gating issue: hand-editing the Firestore doc is error-prone (right collection, right field name) and the current alternative was clunky.

## Usage

From the repo root:

```bash
# Authenticate once per machine if you haven't
gcloud auth application-default login
gcloud config set project xtrafleet-qa

# Grant super admin on QA
firebase use qa
npm run grant-admin:qa edward@xtrafleet.com

# Or pass a specific role
npm run grant-admin:qa edward@xtrafleet.com admin
npm run grant-admin:qa edward@xtrafleet.com support
npm run grant-admin:qa edward@xtrafleet.com billing_admin

# Production
npm run grant-admin:prod some@email.com admin
```

Output looks like:
```
📡 Connecting to Firebase project: xtrafleet-qa
✓ Found auth user: mCKxls4haIWLUzNBcqmmgJu8EJg2
✓ Granted super_admin on owner_operators/mCKxls4haIWLUzNBcqmmgJu8EJg2 (edward@xtrafleet.com).
  Refresh the QA dashboard — the admin sidebar should appear.
```

## What gets written

`owner_operators/{uid}` (merge):
- `isAdmin: true`
- `adminRole: "super_admin"` (or the role passed as the 2nd arg)
- `adminGrantedAt: <ISO timestamp>` — for audit
- `adminGrantedBy: "scripts/grant-admin.ts"` — distinguishable from human writes

## Setup Required
- One-time per developer machine: `gcloud auth application-default login` and (if you haven't) install `tsx`/`firebase-admin` (already in package.json).
- For QA, your gcloud account needs Firestore access on `xtrafleet-qa`.

## Test plan
- [ ] Run `npm run grant-admin:qa edward@xtrafleet.com`. Script prints the uid it found and confirms the write.
- [ ] In the QA Firestore console, `owner_operators/{your-uid}` now has `isAdmin: true` + `adminRole: "super_admin"` + `adminGrantedAt` + `adminGrantedBy`.
- [ ] Refresh `/dashboard` on QA. Admin sidebar appears. `/admin/nodes` and `/admin/attestations` are reachable.
- [ ] Run with an invalid role (`npm run grant-admin:qa edward@xtrafleet.com nope`) — script exits 1 with a clear error listing valid roles.
- [ ] Run with an email that doesn't exist on QA — script exits 1 with a "no user found" error pointing at `firebase use qa`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N15VBWBe1Y8mpwgCq8wtxn)_