### PR TITLE
fix(brand): correct logo geometry and dark-bg treatment per DEV-160

### DIFF
--- a/public/images/xtrafleet-logo-no-tagline.svg
+++ b/public/images/xtrafleet-logo-no-tagline.svg
@@ -1,9 +1,6 @@
 <svg width="2400" height="800" viewBox="0 0 2400 800" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- XtraFleet logo (DEV-160) -->
-  <!-- Top blue curved chevron -->
-  <path d="M 60 90 L 220 90 C 280 200, 340 290, 400 360 C 460 290, 520 200, 580 90 L 740 90 C 600 360, 480 460, 400 460 C 320 460, 200 360, 60 90 Z" fill="#1E9BD7"/>
-  <!-- Bottom dark curved chevron -->
-  <path d="M 60 710 L 220 710 C 280 600, 340 510, 400 440 C 460 510, 520 600, 580 710 L 740 710 C 600 440, 480 340, 400 340 C 320 340, 200 440, 60 710 Z" fill="#2A2D31"/>
-  <!-- "XtraFleet" wordmark -->
-  <text x="860" y="560" font-family="Arial, Helvetica, sans-serif" font-size="540" font-weight="700" fill="#2A2D31" letter-spacing="-12">XtraFleet</text>
+  <!-- XtraFleet full lockup (DEV-160) -->
+  <path d="M 80 110 C 250 180, 550 180, 720 110 C 650 200, 480 280, 400 360 C 320 280, 150 200, 80 110 Z" fill="#1E9BD7"/>
+  <path d="M 80 690 C 250 620, 550 620, 720 690 C 650 600, 480 520, 400 440 C 320 520, 150 600, 80 690 Z" fill="#2A2D31"/>
+  <text x="860" y="540" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="500" font-weight="700" fill="#2A2D31" letter-spacing="-15">XtraFleet</text>
 </svg>

--- a/public/images/xtrafleet-logo.svg
+++ b/public/images/xtrafleet-logo.svg
@@ -1,11 +1,7 @@
 <svg width="2400" height="1000" viewBox="0 0 2400 1000" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- XtraFleet logo with tagline (DEV-160) -->
-  <!-- Top blue curved chevron -->
-  <path d="M 60 90 L 220 90 C 280 200, 340 290, 400 360 C 460 290, 520 200, 580 90 L 740 90 C 600 360, 480 460, 400 460 C 320 460, 200 360, 60 90 Z" fill="#1E9BD7"/>
-  <!-- Bottom dark curved chevron -->
-  <path d="M 60 710 L 220 710 C 280 600, 340 510, 400 440 C 460 510, 520 600, 580 710 L 740 710 C 600 440, 480 340, 400 340 C 320 340, 200 440, 60 710 Z" fill="#2A2D31"/>
-  <!-- "XtraFleet" wordmark -->
-  <text x="860" y="560" font-family="Arial, Helvetica, sans-serif" font-size="540" font-weight="700" fill="#2A2D31" letter-spacing="-12">XtraFleet</text>
-  <!-- Tagline -->
-  <text x="60" y="920" font-family="Arial, Helvetica, sans-serif" font-size="120" font-weight="400" fill="#2A2D31" letter-spacing="2">Powering Fleet Collaboration</text>
+  <!-- XtraFleet full lockup with tagline (DEV-160) -->
+  <path d="M 80 110 C 250 180, 550 180, 720 110 C 650 200, 480 280, 400 360 C 320 280, 150 200, 80 110 Z" fill="#1E9BD7"/>
+  <path d="M 80 690 C 250 620, 550 620, 720 690 C 650 600, 480 520, 400 440 C 320 520, 150 600, 80 690 Z" fill="#2A2D31"/>
+  <text x="860" y="540" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="500" font-weight="700" fill="#2A2D31" letter-spacing="-15">XtraFleet</text>
+  <text x="80" y="920" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="120" font-weight="400" fill="#2A2D31" letter-spacing="2">Powering Fleet Collaboration</text>
 </svg>

--- a/public/images/xtrafleet-logomark.svg
+++ b/public/images/xtrafleet-logomark.svg
@@ -1,7 +1,5 @@
 <svg width="800" height="800" viewBox="0 0 800 800" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- XtraFleet logomark (DEV-160) -->
-  <!-- Top blue curved chevron -->
-  <path d="M 60 90 L 220 90 C 280 200, 340 290, 400 360 C 460 290, 520 200, 580 90 L 740 90 C 600 360, 480 460, 400 460 C 320 460, 200 360, 60 90 Z" fill="#1E9BD7"/>
-  <!-- Bottom dark curved chevron -->
-  <path d="M 60 710 L 220 710 C 280 600, 340 510, 400 440 C 460 510, 520 600, 580 710 L 740 710 C 600 440, 480 340, 400 340 C 320 340, 200 440, 60 710 Z" fill="#2A2D31"/>
+  <!-- XtraFleet logomark (DEV-160) - clean curved-V chevrons -->
+  <path d="M 80 110 C 250 180, 550 180, 720 110 C 650 200, 480 280, 400 360 C 320 280, 150 200, 80 110 Z" fill="#1E9BD7"/>
+  <path d="M 80 690 C 250 620, 550 620, 720 690 C 650 600, 480 520, 400 440 C 320 520, 150 600, 80 690 Z" fill="#2A2D31"/>
 </svg>

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -2,27 +2,35 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 
 const BRAND_BLUE = "#1E9BD7";
+const BRAND_DARK = "#2A2D31";
 
-// Curved-X logomark per DEV-160. Top half is the brand-blue inverted curved-V;
-// bottom half mirrors it and adapts to theme (dark in light mode, white in dark).
+// DEV-160 logomark: clean curved-V (top blue, bottom dark charcoal) forming a
+// stylized X with a horizontal gap. On dark surfaces (forceLight or .dark),
+// both halves render white as a knockout/reverse treatment.
 function LogomarkPaths({ forceLight }: { forceLight?: boolean }) {
-  const bottomFill = forceLight ? "fill-white" : "fill-gray-900 dark:fill-white";
+  const topClass = forceLight ? "fill-white" : "dark:fill-white";
+  const bottomClass = forceLight ? "fill-white" : "dark:fill-white";
+  const topFill = forceLight ? undefined : BRAND_BLUE;
+  const bottomFill = forceLight ? undefined : BRAND_DARK;
   return (
     <>
       <path
-        d="M 60 90 L 220 90 C 280 200, 340 290, 400 360 C 460 290, 520 200, 580 90 L 740 90 C 600 360, 480 460, 400 460 C 320 460, 200 360, 60 90 Z"
-        fill={BRAND_BLUE}
+        d="M 80 110 C 250 180, 550 180, 720 110 C 650 200, 480 280, 400 360 C 320 280, 150 200, 80 110 Z"
+        fill={topFill}
+        className={topClass}
       />
       <path
-        d="M 60 710 L 220 710 C 280 600, 340 510, 400 440 C 460 510, 520 600, 580 710 L 740 710 C 600 440, 480 340, 400 340 C 320 340, 200 440, 60 710 Z"
-        className={bottomFill}
+        d="M 80 690 C 250 620, 550 620, 720 690 C 650 600, 480 520, 400 440 C 320 520, 150 600, 80 690 Z"
+        fill={bottomFill}
+        className={bottomClass}
       />
     </>
   );
 }
 
 function LogoFull({ className, forceLight }: { className?: string; forceLight?: boolean }) {
-  const textFill = forceLight ? "fill-white" : "fill-gray-900 dark:fill-white";
+  const textClass = forceLight ? "fill-white" : "dark:fill-white";
+  const textFill = forceLight ? undefined : BRAND_DARK;
   return (
     <svg
       viewBox="0 0 2400 800"
@@ -34,12 +42,13 @@ function LogoFull({ className, forceLight }: { className?: string; forceLight?: 
       <LogomarkPaths forceLight={forceLight} />
       <text
         x="860"
-        y="560"
-        fontFamily="Arial, Helvetica, sans-serif"
-        fontSize="540"
+        y="540"
+        fontFamily="Inter, ui-sans-serif, system-ui, sans-serif"
+        fontSize="500"
         fontWeight="700"
-        className={textFill}
-        letterSpacing="-12"
+        fill={textFill}
+        className={textClass}
+        letterSpacing="-15"
       >
         XtraFleet
       </text>


### PR DESCRIPTION
## Summary
- Follow-up fix to PR #143. The first pass on DEV-160 had two bugs that made the rendered logo read very differently from the Jira design:
  1. The SVG path had an inner notch on the top edge (stale chevron artifact), so the shape looked like an "M" rather than the clean curved-V in the design.
  2. `forceLight` left the top chevron blue, so on the dark dashboard/admin sidebars the logo rendered half-blue / half-white instead of the intended all-white reverse.

## Changes
- `src/components/logo.tsx` — replaced the path with a 3-corner curved-V (cubic Bezier along each of the three edges: gentle concave dip across the top, convex bulges down the outer left/right). `forceLight` and the `.dark` parent class now both flip every fill — top chevron, bottom chevron, and wordmark — to white. Wordmark switched to Inter (the project body font, per `tailwind.config.ts`) instead of Arial.
- `public/images/xtrafleet-logo.svg` — full lockup with tagline.
- `public/images/xtrafleet-logo-no-tagline.svg` — full lockup, used in the email template (`src/lib/email.ts:21`) and OG/Twitter meta (`src/app/layout.tsx:28,34`).
- `public/images/xtrafleet-logomark.svg` — standalone logomark.

## Setup Required
- None.

## Test Plan
- [ ] On QA: confirm dashboard sidebar (`/dashboard`), admin sidebar (`/admin`), and driver dashboard sidebar render the logo as **all white** (not half-blue).
- [ ] On QA: confirm marketing/auth/onboarding pages render the logo as **blue + dark charcoal** (light treatment).
- [ ] Compare against the Jira DEV-160 design — shape should now read as a clean curved-V (no inner top notch).
- [ ] Send a test transactional email and confirm the logo at the top renders correctly in Gmail / Apple Mail (light bg, blue + charcoal).
- [ ] Confirm OG / Twitter card preview still shows the new logo (Slack unfurl or `https://www.opengraph.xyz/`).
- [ ] No console errors on any logo-bearing page.

> If the curve geometry still doesn't match the design closely enough, send the source SVG (or a higher-res PNG) and I'll re-trace.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_