### PR TITLE
feat(legal): gate User Agreement to authenticated areas + bump consent versions (DEV-77)

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -249,6 +249,19 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             <div className="ml-auto text-sm text-muted-foreground">{user?.email}</div>
           </header>
           <main className="flex-1 overflow-auto p-4 md:p-6">{children}</main>
+          <footer className="border-t bg-background px-4 py-3">
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-2">
+              <p className="text-xs text-muted-foreground">
+                &copy; {new Date().getFullYear()} XtraFleet. All rights reserved.
+              </p>
+              <nav className="flex flex-wrap justify-center gap-3 text-xs">
+                <Link href="/legal/terms" className="text-muted-foreground hover:text-foreground transition-colors">Terms of Service</Link>
+                <Link href="/legal/privacy" className="text-muted-foreground hover:text-foreground transition-colors">Privacy Policy</Link>
+                <Link href="/legal/user-agreement" className="text-muted-foreground hover:text-foreground transition-colors">User Agreement</Link>
+                <Link href="/legal/esign-consent" className="text-muted-foreground hover:text-foreground transition-colors">E-Sign Agreement</Link>
+              </nav>
+            </div>
+          </footer>
         </SidebarInset>
         <AlertDialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>
           <AlertDialogContent>

--- a/src/app/driver-dashboard/layout.tsx
+++ b/src/app/driver-dashboard/layout.tsx
@@ -224,6 +224,19 @@ export default function DriverDashboardLayout({
         <main className="flex-1 overflow-auto p-4 md:p-6">
           {children}
         </main>
+        <footer className="border-t bg-background px-4 py-3">
+          <div className="flex flex-col sm:flex-row justify-between items-center gap-2">
+            <p className="text-xs text-muted-foreground">
+              &copy; {new Date().getFullYear()} XtraFleet. All rights reserved.
+            </p>
+            <nav className="flex flex-wrap justify-center gap-3 text-xs">
+              <Link href="/legal/terms" className="text-muted-foreground hover:text-foreground transition-colors">Terms of Service</Link>
+              <Link href="/legal/privacy" className="text-muted-foreground hover:text-foreground transition-colors">Privacy Policy</Link>
+              <Link href="/legal/user-agreement" className="text-muted-foreground hover:text-foreground transition-colors">User Agreement</Link>
+              <Link href="/legal/esign-consent" className="text-muted-foreground hover:text-foreground transition-colors">E-Sign Agreement</Link>
+            </nav>
+          </div>
+        </footer>
       </SidebarInset>
 
       <AlertDialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -97,12 +97,12 @@ function RegisterContent() {
             userAgreement: {
               accepted: true,
               acceptedAt: new Date().toISOString(),
-              version: "2025-10-17",
+              version: "2026-04-29",
             },
             esignAgreement: {
               accepted: true,
               acceptedAt: new Date().toISOString(),
-              version: "2025-01-29",
+              version: "2026-04-29",
             },
           },
         });

--- a/src/components/driver-register-form.tsx
+++ b/src/components/driver-register-form.tsx
@@ -104,12 +104,12 @@ export function DriverRegisterForm({
             userAgreement: {
               accepted: true,
               acceptedAt: new Date().toISOString(),
-              version: "2025-10-17",
+              version: "2026-04-29",
             },
             esignAgreement: {
               accepted: true,
               acceptedAt: new Date().toISOString(),
-              version: "2025-01-29",
+              version: "2026-04-29",
             },
           },
         }),

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -26,20 +26,14 @@ export function Footer() {
             >
               Terms of Service
             </Link>
-            <Link 
-              href="/legal/privacy" 
+            <Link
+              href="/legal/privacy"
               className="text-muted-foreground hover:text-foreground transition-colors"
             >
               Privacy Policy
             </Link>
-            <Link 
-              href="/legal/user-agreement" 
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              User Agreement
-            </Link>
-            <Link 
-              href="/legal/esign-consent" 
+            <Link
+              href="/legal/esign-consent"
               className="text-muted-foreground hover:text-foreground transition-colors"
             >
               E-Sign Agreement


### PR DESCRIPTION
**Closing in favor of #146.** Original branch was cut from `main`, but qa is far ahead — DEV-154 had already replaced the `consents.{userAgreement,esignAgreement}` model with a unified `attestations[]` array, so the version-bump portion of this PR was hitting a model that no longer exists on qa. Force-push to fix this branch was blocked by the remote, so the rebased work was opened as a fresh PR against `qa`.