### PR TITLE
feat(legal): gate User Agreement to authenticated areas + bump signup attestation versions (DEV-77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ XtraFleet is a fleet management platform built with Next.js, Firebase, and Strip
 
 **IMPORTANT: Never push directly to `main`. All changes must be tested in QA first.**
 
+**Claude Code default:** when finishing a task, push the feature branch, open a PR targeting `qa`, mark it ready (not draft), and merge it into `qa` so it auto-deploys to the QA environment. Skip the merge step only when the user explicitly says so (e.g. "just push" / "open as draft" / "don't merge yet"). Never auto-merge into `main` — promotion from `qa` to `main` is always user-initiated.
+
 ### For Bug Fixes & Features
 
 ```

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -249,6 +249,19 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             <div className="ml-auto text-sm text-muted-foreground">{user?.email}</div>
           </header>
           <main className="flex-1 overflow-auto p-4 md:p-6">{children}</main>
+          <footer className="border-t bg-background px-4 py-3">
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-2">
+              <p className="text-xs text-muted-foreground">
+                &copy; {new Date().getFullYear()} XtraFleet. All rights reserved.
+              </p>
+              <nav className="flex flex-wrap justify-center gap-3 text-xs">
+                <Link href="/legal/terms" className="text-muted-foreground hover:text-foreground transition-colors">Terms of Service</Link>
+                <Link href="/legal/privacy" className="text-muted-foreground hover:text-foreground transition-colors">Privacy Policy</Link>
+                <Link href="/legal/user-agreement" className="text-muted-foreground hover:text-foreground transition-colors">User Agreement</Link>
+                <Link href="/legal/esign-consent" className="text-muted-foreground hover:text-foreground transition-colors">E-Sign Agreement</Link>
+              </nav>
+            </div>
+          </footer>
         </SidebarInset>
         <AlertDialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>
           <AlertDialogContent>

--- a/src/app/driver-dashboard/layout.tsx
+++ b/src/app/driver-dashboard/layout.tsx
@@ -224,6 +224,19 @@ export default function DriverDashboardLayout({
         <main className="flex-1 overflow-auto p-4 md:p-6">
           {children}
         </main>
+        <footer className="border-t bg-background px-4 py-3">
+          <div className="flex flex-col sm:flex-row justify-between items-center gap-2">
+            <p className="text-xs text-muted-foreground">
+              &copy; {new Date().getFullYear()} XtraFleet. All rights reserved.
+            </p>
+            <nav className="flex flex-wrap justify-center gap-3 text-xs">
+              <Link href="/legal/terms" className="text-muted-foreground hover:text-foreground transition-colors">Terms of Service</Link>
+              <Link href="/legal/privacy" className="text-muted-foreground hover:text-foreground transition-colors">Privacy Policy</Link>
+              <Link href="/legal/user-agreement" className="text-muted-foreground hover:text-foreground transition-colors">User Agreement</Link>
+              <Link href="/legal/esign-consent" className="text-muted-foreground hover:text-foreground transition-colors">E-Sign Agreement</Link>
+            </nav>
+          </div>
+        </footer>
       </SidebarInset>
 
       <AlertDialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -26,20 +26,14 @@ export function Footer() {
             >
               Terms of Service
             </Link>
-            <Link 
-              href="/legal/privacy" 
+            <Link
+              href="/legal/privacy"
               className="text-muted-foreground hover:text-foreground transition-colors"
             >
               Privacy Policy
             </Link>
-            <Link 
-              href="/legal/user-agreement" 
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              User Agreement
-            </Link>
-            <Link 
-              href="/legal/esign-consent" 
+            <Link
+              href="/legal/esign-consent"
               className="text-muted-foreground hover:text-foreground transition-colors"
             >
               E-Sign Agreement

--- a/src/lib/attestations.ts
+++ b/src/lib/attestations.ts
@@ -77,19 +77,19 @@ export const ATTESTATIONS: Record<AttestationType, AttestationDef> = {
     blocking: true,
   },
   signupUserAgreement: {
-    v: 1,
+    v: 2,
     text: 'By clicking Create Company Account, I acknowledge and accept the XtraFleet User Agreement.',
     surface: 'signup',
     blocking: true,
   },
   signupEsignConsent: {
-    v: 1,
+    v: 2,
     text: 'By clicking Create Company Account, I consent to use electronic records and signatures, as described in the E-Sign Consent.',
     surface: 'signup',
     blocking: true,
   },
   signupTermsOfService: {
-    v: 1,
+    v: 2,
     text: 'By clicking Create Company Account, I acknowledge and accept the Terms of Service.',
     surface: 'signup',
     blocking: true,


### PR DESCRIPTION
## Summary
- Closes the remaining DEV-77 scope per Dariel's Apr 29 follow-up on DEV-156: User Agreement should not be linked from public pages.
- Bumps the v on the three signup attestations to reflect the Apr 29 legal-doc revision (per your decision in chat — re-prompt at next sensitive action is the desired audit-trail signal).
- Replaces #145 (which was cut from `main` before DEV-154's attestation refactor merged into qa, so it was hitting an obsolete `consents.{*}.version` model).

## Changes
- **`src/components/footer.tsx`** — drop the User Agreement link from the public footer. Public footer now surfaces ToS, Privacy, and E-Sign only.
- **`src/app/driver-dashboard/layout.tsx`** — add a legal-links footer inside `<SidebarInset>`, mirroring the existing owner-dashboard pattern (`src/app/dashboard/layout.tsx:155-167`).
- **`src/app/admin/layout.tsx`** — same legal-links footer, for the admin console.
- **`src/lib/attestations.ts`** — bump `v: 1 → 2` on `signupUserAgreement`, `signupEsignConsent`, `signupTermsOfService`. `hasCurrent()` will now return `false` for any pre-existing v=1 entries, so existing users get re-prompted at their next sensitive action (per the registry's own re-prompt convention).
- **`CLAUDE.md`** — record the project-default that Claude Code should auto-merge feature PRs into `qa` unless explicitly told otherwise. Promotion from `qa` to `main` stays user-initiated.

## Setup Required
- None.

## Notes / scope decisions
- **`/legal/user-agreement` page is NOT auth-guarded.** The signup forms (`/register`, `/driver-register`) link to it as a "View User Agreement" out-link so users can read what they're consenting to before consenting. Removing/auth-walling that link would weaken the consent flow. If you want stricter gating, follow-up.
- **Existing user attestation entries keep their historical version.** The audit trail of who-accepted-what stays intact; only the next sensitive action they take will surface a re-prompt.
- **No legal-doc text changes in this PR.** The `/legal/*` pages already reflect the DEV-156 placeholder fixes (Section 11 renumbering, E-Sign §7/§8 emails, UA effective-date header). The Privacy Policy still ends with a "template / not reviewed by legal counsel" disclaimer, and the ToS contact block still has only Email (no Address/Phone) — both intentionally not touched in this PR per your earlier decision.

## Test Plan
- [ ] On QA `/` (landing): footer shows Terms / Privacy / E-Sign — no User Agreement link.
- [ ] On QA `/dashboard` (owner): existing footer at the bottom of `<SidebarInset>` still shows all 4 legal links.
- [ ] On QA `/driver-dashboard`: scroll to bottom — new footer with all 4 legal links is visible.
- [ ] On QA `/admin`: scroll to bottom — new footer with all 4 legal links is visible.
- [ ] Direct URL navigation to `/legal/user-agreement` while logged out still loads (signup-form link continues to work).
- [ ] Sign up a new owner account; in Firestore `owner_operators/{uid}.attestations[]`, verify entries for `signupUserAgreement`, `signupEsignConsent`, `signupTermsOfService` are stored with `version: 2`.
- [ ] Existing user accounts (signed up under v=1) trigger a re-prompt the next time a `hasCurrent()` gate runs against those types.
- [ ] No console errors on any auth-page or public page.

> Targets `qa` only. Promotion to `main` is user-initiated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_