### PR TITLE
fix(brand): widen logo viewBox so 'XtraFleet' wordmark no longer clips

### DIFF
--- a/public/images/xtrafleet-logo-no-tagline.svg
+++ b/public/images/xtrafleet-logo-no-tagline.svg
@@ -1,4 +1,4 @@
-<svg width="2400" height="800" viewBox="0 0 2400 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="3600" height="800" viewBox="0 0 3600 800" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- XtraFleet full lockup (DEV-160) -->
   <path d="M 80 110 C 250 180, 550 180, 720 110 C 650 200, 480 280, 400 360 C 320 280, 150 200, 80 110 Z" fill="#1E9BD7"/>
   <path d="M 80 690 C 250 620, 550 620, 720 690 C 650 600, 480 520, 400 440 C 320 520, 150 600, 80 690 Z" fill="#2A2D31"/>

--- a/public/images/xtrafleet-logo.svg
+++ b/public/images/xtrafleet-logo.svg
@@ -1,4 +1,4 @@
-<svg width="2400" height="1000" viewBox="0 0 2400 1000" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="3600" height="1000" viewBox="0 0 3600 1000" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- XtraFleet full lockup with tagline (DEV-160) -->
   <path d="M 80 110 C 250 180, 550 180, 720 110 C 650 200, 480 280, 400 360 C 320 280, 150 200, 80 110 Z" fill="#1E9BD7"/>
   <path d="M 80 690 C 250 620, 550 620, 720 690 C 650 600, 480 520, 400 440 C 320 520, 150 600, 80 690 Z" fill="#2A2D31"/>

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -33,7 +33,7 @@ function LogoFull({ className, forceLight }: { className?: string; forceLight?: 
   const textFill = forceLight ? undefined : BRAND_DARK;
   return (
     <svg
-      viewBox="0 0 2400 800"
+      viewBox="0 0 3600 800"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}


### PR DESCRIPTION
## Summary
- Temporary fix for the "XtraFleet" wordmark being clipped to "XtraFle" in the deployed logo on QA. Will be superseded once the source SVG from the brand designer lands.

## Diagnosis
PR #144 set `LogoFull`'s svg `viewBox` to `0 0 2400 800`. The wordmark `<text>` at `fontSize=500` starting at `x=860` actually extends to ~`x=3185`, overflowing the right edge of the 2400-unit-wide viewBox by ~785 units. SVG clips content past the viewBox, so the final ~3 characters render but are invisible — the deployed logo reads **"XtraFle"** instead of **"XtraFleet"**.

## Changes
- **`src/components/logo.tsx`** — `viewBox` `0 0 2400 800` → `0 0 3600 800` on the inline `LogoFull` svg.
- **`public/images/xtrafleet-logo-no-tagline.svg`** — same widen on the static asset (used by email templates and OG meta).
- **`public/images/xtrafleet-logo.svg`** — same widen on the with-tagline asset (viewBox height stays 1000).
- **`public/images/xtrafleet-logomark.svg`** — untouched; logomark-only file contains no text, no clipping risk.

Visual proportions inside each logo are unchanged. The rendered natural width at `h-10` grows from ~120px to ~180px, close to what the previous chevron logo took.

## Setup Required
- None.

## Test Plan
- [ ] On QA `/`: header logo reads the full word **"XtraFleet"** with no clipping at the right edge.
- [ ] Hover state still works (no layout shift).
- [ ] Dashboard / admin / driver-dashboard sidebar headers still render the logo correctly under `forceLight`.
- [ ] Transactional email preview: the `xtrafleet-logo-no-tagline.svg` at the top of the welcome email renders the full word.
- [ ] OG / Twitter unfurl preview (Slack or `https://www.opengraph.xyz/`) still shows the logo properly.
- [ ] No console errors.

> Temporary fix — once you upload the designer's source SVG, we'll replace the inline paths entirely. Targets `qa` per project default.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_