### PR TITLE
fix(brand): use designer X for favicon + PWA icons (DEV-160)

### DIFF
--- a/public/icons/icon-128x128.svg
+++ b/public/icons/icon-128x128.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" rx="20" fill="white"/>
-  <path d="M64 61 L24 21 L34 21 L64 51 L94 21 L104 21 L64 61 Z" fill="#1E9BD7"/>
-  <path d="M64 67 L24 107 L34 107 L64 77 L94 107 L104 107 L64 67 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon-144x144.svg
+++ b/public/icons/icon-144x144.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <rect width="144" height="144" rx="22" fill="white"/>
-  <path d="M72 69 L27 24 L38 24 L72 58 L106 24 L117 24 L72 69 Z" fill="#1E9BD7"/>
-  <path d="M72 75 L27 120 L38 120 L72 86 L106 120 L117 120 L72 75 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon-152x152.svg
+++ b/public/icons/icon-152x152.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 152 152">
-  <rect width="152" height="152" rx="24" fill="white"/>
-  <path d="M76 73 L28 25 L40 25 L76 61 L112 25 L124 25 L76 73 Z" fill="#1E9BD7"/>
-  <path d="M76 79 L28 127 L40 127 L76 91 L112 127 L124 127 L76 79 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon-192x192.svg
+++ b/public/icons/icon-192x192.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
-  <rect width="192" height="192" rx="30" fill="white"/>
-  <path d="M96 92 L36 32 L50 32 L96 78 L142 32 L156 32 L96 92 Z" fill="#1E9BD7"/>
-  <path d="M96 100 L36 160 L50 160 L96 114 L142 160 L156 160 L96 100 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon-384x384.svg
+++ b/public/icons/icon-384x384.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 384">
-  <rect width="384" height="384" rx="60" fill="white"/>
-  <path d="M192 184 L72 64 L100 64 L192 156 L284 64 L312 64 L192 184 Z" fill="#1E9BD7"/>
-  <path d="M192 200 L72 320 L100 320 L192 228 L284 320 L312 320 L192 200 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon-512x512.svg
+++ b/public/icons/icon-512x512.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <rect width="512" height="512" rx="80" fill="white"/>
-  <path d="M256 245 L96 85 L136 85 L256 205 L376 85 L416 85 L256 245 Z" fill="#1E9BD7"/>
-  <path d="M256 267 L96 427 L136 427 L256 307 L376 427 L416 427 L256 267 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon-72x72.svg
+++ b/public/icons/icon-72x72.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
-  <rect width="72" height="72" rx="12" fill="white"/>
-  <path d="M36 34.5 L14 12.5 L20 12.5 L36 28.5 L52 12.5 L58 12.5 L36 34.5 Z" fill="#1E9BD7"/>
-  <path d="M36 37.5 L14 59.5 L20 59.5 L36 43.5 L52 59.5 L58 59.5 L36 37.5 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon-96x96.svg
+++ b/public/icons/icon-96x96.svg
@@ -1,5 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
-  <rect width="96" height="96" rx="16" fill="white"/>
-  <path d="M48 46 L18 16 L26 16 L48 38 L70 16 L78 16 L48 46 Z" fill="#1E9BD7"/>
-  <path d="M48 50 L18 80 L26 80 L48 58 L70 80 L78 80 L48 50 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>

--- a/public/icons/icon.svg
+++ b/public/icons/icon.svg
@@ -1,8 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <rect width="512" height="512" rx="80" fill="white"/>
-  <!-- XtraFleet X Logomark -->
-  <!-- Blue top chevron (pointing down) -->
-  <path d="M256 245 L96 85 L136 85 L256 205 L376 85 L416 85 L256 245 Z" fill="#1E9BD7"/>
-  <!-- Dark gray bottom chevron (pointing up) -->
-  <path d="M256 267 L96 427 L136 427 L256 307 L376 427 L416 427 L256 267 Z" fill="#333333"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- XtraFleet app icon: designer X centered on white rounded square.
+       The X is sized to ~80% of the canvas so it stays inside the safe
+       zone when used as a maskable PWA icon on Android. -->
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <svg x="51" y="85" width="410" height="342" viewBox="0 0 1039.4893 866.85332" preserveAspectRatio="xMidYMid meet">
+    <defs>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipTop">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-355.50791)"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="iconClipBottom">
+        <path d="M 0,650.14 H 779.617 V 0 H 0 Z" transform="translate(-252.85651,-294.63191)"/>
+      </clipPath>
+    </defs>
+    <g transform="translate(-32200)">
+      <path
+        d="M 0,0 -250.357,292.547 H -15.234 L 131.517,109.316 288.897,292.547 H 524.261 L 409.012,166.822 C 308.168,53.275 151.862,0 0,0"
+        style="fill:#108dc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,392.8428)"
+        clip-path="url(#iconClipTop)" />
+      <path
+        d="m 0,0 -250.357,-292.547 h 235.123 l 146.751,183.231 157.38,-183.231 H 524.261 L 409.012,-166.822 C 308.168,-53.275 151.862,0 0,0"
+        style="fill:#2c2c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+        transform="matrix(1.3333333,0,0,-1.3333333,32537.142,474.0108)"
+        clip-path="url(#iconClipBottom)" />
+    </g>
+  </svg>
 </svg>


### PR DESCRIPTION
## Summary
- Replaces the favicon + PWA icon set with the new designer X. Previously every `public/icons/icon*.svg` still rendered the old hand-traced chevron X.
- Closes the icon side of DEV-160 (modulo the binary `.ico` fallback — see notes).

## Changes
- **`public/icons/icon.svg`** (and all sized variants `icon-72x72.svg` … `icon-512x512.svg`) — rewritten as a 512×512 wrapper with:
  - The same white rounded-square background as before (`rx="80"`).
  - The new designer X embedded via a nested `<svg>` at `x="51" y="85" width="410" height="342"`, keeping ~20% margin on all sides so the icon stays in the **maskable safe zone** for Android adaptive icons.
  - The original two-color brand treatment (`#108dc4` + `#2c2c2c`) — no theme-adaptive trick; browser-tab and install-icon surfaces are background-controlled, so the static brand colors are correct.
- All sized variants get the same content because SVG scales. `manifest.json` continues to reference each file unchanged.
- Apple touch icon (`<link rel="apple-touch-icon">` at `src/app/layout.tsx:59`) and `metadata.icons.apple` already point into `public/icons/`, so they pick up the new content automatically.

## Not in this PR (separate manual step)
- **`src/app/favicon.ico`** is still the bitmap render of the old chevron. Modern browsers prefer the SVG icon via `metadata.icons.icon`, so the effective browser-tab icon on Chrome / Safari / Firefox / Edge is the new one. The `.ico` fallback only matters for legacy browsers. To replace it:
  1. Upload `public/images/xtrafleet-logomark.svg` to [favicon.io/favicon-converter](https://favicon.io/favicon-converter/).
  2. Download the generated `favicon.ico`.
  3. Drop it at `src/app/favicon.ico` and commit.

## Setup Required
- None.

## Test Plan
- [ ] On QA: open `/`, look at the browser tab — should show the new designer X (Chrome / Safari / Firefox / Edge).
- [ ] On QA: "Install app" / "Add to Home Screen" prompt — the install icon should be the new X on a white rounded square.
- [ ] Inspect: `view-source:` and confirm `<link rel="icon" href="/icons/icon.svg">` resolves to a file whose SVG payload contains `#108dc4` (the new brand blue), not `#1E9BD7` (the old chevron blue).
- [ ] On a low-end Android (or Chrome devtools mobile emulator) verify the maskable icon still reads correctly when cropped into a circle / squircle — the X should remain visible with margin.
- [ ] No console errors.

> Targets `qa`. The remaining `.ico` regen is a small follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_