### PR TITLE
feat(drivers): let OOs complete their self-driver profile from the owner dashboard

### DIFF
--- a/src/app/api/submit-self-driver-profile/route.ts
+++ b/src/app/api/submit-self-driver-profile/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { handleApiError, handleApiSuccess } from '@/lib/api-error-handler';
+import { withCors } from '@/lib/api-cors';
+import { logAuditEvent, AuditActions } from '@/lib/audit-logger';
+
+const LOG_PREFIX = '[submit-self-driver-profile]';
+
+const bodySchema = z.object({
+  driverId: z.string().min(1, 'driverId required'),
+  profileData: z.record(z.any()),
+  consents: z.record(z.any()),
+  deviceInfo: z.record(z.any()).optional(),
+});
+
+async function verifyToken(auth: any, tokenValue: string) {
+  try {
+    return await auth.verifySessionCookie(tokenValue, true);
+  } catch {
+    return await auth.verifyIdToken(tokenValue);
+  }
+}
+
+// OO-self-driver completion endpoint. Mirrors /api/submit-driver-profile but
+// the calling user is the OWNER, not the driver — the driver doc has an
+// auto-generated id (not the owner's uid) and isSelfDriver === true.
+async function handlePost(req: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+    const token = req.cookies.get('fb-id-token');
+    if (!token) {
+      console.warn(`${LOG_PREFIX} No auth token found in cookies`);
+      throw new Error('Unauthorized');
+    }
+
+    const user = await verifyToken(auth, token.value);
+    console.log(`${LOG_PREFIX} Authenticated owner uid: ${user.uid}`);
+
+    const body = await req.json();
+    const validation = bodySchema.safeParse(body);
+    if (!validation.success) {
+      const errs = Object.values(validation.error.flatten().fieldErrors).flat().join(', ');
+      throw new Error(errs || 'Invalid request body');
+    }
+    const { driverId, profileData, consents, deviceInfo } = validation.data;
+
+    // Verify the caller actually owns the target driver record and that the
+    // record is flagged as a self-driver. This is the only path that lets an
+    // OO write to a driver doc they don't have a matching uid for.
+    const driverRef = db
+      .collection('owner_operators')
+      .doc(user.uid)
+      .collection('drivers')
+      .doc(driverId);
+
+    const driverDoc = await driverRef.get();
+    if (!driverDoc.exists()) {
+      console.error(`${LOG_PREFIX} Driver doc not found at owner_operators/${user.uid}/drivers/${driverId}`);
+      throw new Error('Driver document not found');
+    }
+    const driverData = driverDoc.data() || {};
+    if (driverData.isSelfDriver !== true) {
+      console.error(`${LOG_PREFIX} Driver ${driverId} is not a self-driver record — refusing to update via this endpoint`);
+      throw new Error('Driver is not a self-driver record');
+    }
+
+    const ipAddress = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || 'unknown';
+    const timestamp = new Date().toISOString();
+    const enhancedConsents = Object.entries(consents).reduce(
+      (acc, [key, value]: [string, any]) => ({
+        ...acc,
+        [key]: {
+          ...value,
+          ipAddress,
+          deviceInfo: deviceInfo || {},
+          timestamp,
+        },
+      }),
+      {},
+    );
+
+    // Match the field normalization /api/submit-driver-profile does so the
+    // compliance engine sees one canonical shape.
+    const normalizedProfileData = { ...profileData };
+    if (normalizedProfileData.medicalCertExpiration !== undefined) {
+      normalizedProfileData.medicalCardExpiry = normalizedProfileData.medicalCertExpiration;
+      delete normalizedProfileData.medicalCertExpiration;
+    }
+
+    await driverRef.update({
+      ...normalizedProfileData,
+      driverConsents: enhancedConsents,
+      profileStatus: 'pending_confirmation',
+      profileSubmittedAt: FieldValue.serverTimestamp(),
+      profileComplete: false,
+    });
+
+    console.log(`${LOG_PREFIX} Self-driver profile saved for owner ${user.uid}, driverDoc ${driverId}`);
+
+    await logAuditEvent({
+      action: AuditActions.DRIVER_PROFILE_SUBMITTED,
+      userId: user.uid,
+      userRole: 'owner_operator',
+      targetId: driverId,
+      targetType: 'driver',
+      metadata: {
+        selfDriver: true,
+        cdlState: normalizedProfileData.cdlState,
+        cdlClass: normalizedProfileData.cdlClass,
+        hasEndorsements: Array.isArray(normalizedProfileData.endorsements) && normalizedProfileData.endorsements.length > 0,
+        medicalCardExpiry: normalizedProfileData.medicalCardExpiry,
+      },
+      ipAddress,
+      userAgent: req.headers.get('user-agent') || undefined,
+    });
+
+    // Skip the owner-notification email — the owner IS the submitter here, so
+    // no need to email themselves.
+
+    return handleApiSuccess({
+      success: true,
+      profileStatus: 'pending_confirmation',
+      message: 'Self-driver profile submitted successfully.',
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`${LOG_PREFIX} Error:`, errorMessage, error);
+    if (errorMessage === 'Unauthorized') {
+      return handleApiError('unauthorized', error instanceof Error ? error : new Error(errorMessage), {
+        endpoint: 'POST /api/submit-self-driver-profile',
+      });
+    }
+    return handleApiError('server', error instanceof Error ? error : new Error(errorMessage), {
+      endpoint: 'POST /api/submit-self-driver-profile',
+    });
+  }
+}
+
+export const POST = withCors(handlePost);

--- a/src/app/dashboard/drivers/page.tsx
+++ b/src/app/dashboard/drivers/page.tsx
@@ -16,9 +16,10 @@ import {
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Sheet, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { AddDriverForm } from "@/components/add-driver-form";
 import { AddSelfAsDriverButton } from "@/components/add-self-as-driver-button";
+import { DriverProfileCompletion } from "@/components/driver-profile-completion";
 import { EditDriverModal } from "@/components/edit-driver-modal";
 import { DriverStatusBadge } from "@/components/driver-status-badge";
 import { DriverConfirmationCard } from "@/components/driver-confirmation-card";
@@ -202,6 +203,7 @@ export default function DriversPage() {
   const [editingDriver, setEditingDriver] = useState<Driver | null>(null);
   const [togglingDriver, setTogglingDriver] = useState<Driver | null>(null);
   const [isToggling, setIsToggling] = useState(false);
+  const [completeSelfProfileOpen, setCompleteSelfProfileOpen] = useState(false);
   // OO doc — fetched once so FMCSA section gets real DOT/MC numbers
   const [ooDoc, setOoDoc] = useState<Partial<OwnerOperator> | undefined>(undefined);
   const { user, isUserLoading } = useUser();
@@ -397,6 +399,20 @@ export default function DriversPage() {
           </div>
         </div>
 
+        {selectedDriver.isSelfDriver && selectedDriver.profileComplete !== true && selectedDriver.profileStatus !== 'pending_confirmation' && selectedDriver.profileStatus !== 'complete' && (
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+              <span>
+                Your driver profile is incomplete. Finish it to clear the Driver Authorization &amp; Disclosure attestation and unlock driver-side compliance.
+              </span>
+              <Button size="sm" onClick={() => setCompleteSelfProfileOpen(true)}>
+                Complete Driver Profile
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
         <Separator />
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -467,6 +483,29 @@ export default function DriversPage() {
           driver={editingDriver}
           onSuccess={() => setSelectedDriverId(selectedDriverId)}
         />
+
+        {selectedDriver.isSelfDriver && (
+          <Sheet open={completeSelfProfileOpen} onOpenChange={setCompleteSelfProfileOpen}>
+            <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+              <SheetHeader>
+                <SheetTitle>Complete Your Driver Profile</SheetTitle>
+                <SheetDescription>
+                  Finish the driver-side fields and sign the Driver Authorization &amp; Disclosure. After submit, the compliance scorecard updates.
+                </SheetDescription>
+              </SheetHeader>
+              <div className="mt-4">
+                <DriverProfileCompletion
+                  driverId={selectedDriver.id}
+                  endpoint="/api/submit-self-driver-profile"
+                  onComplete={() => {
+                    setCompleteSelfProfileOpen(false);
+                    setSelectedDriverId(selectedDriverId);
+                  }}
+                />
+              </div>
+            </SheetContent>
+          </Sheet>
+        )}
       </div>
     );
   }

--- a/src/components/driver-profile-completion.tsx
+++ b/src/components/driver-profile-completion.tsx
@@ -62,9 +62,19 @@ type ProfileValues = z.infer<typeof profileSchema>;
 interface DriverProfileCompletionProps {
   driverId: string;
   onComplete?: () => void;
+  /**
+   * Submission endpoint. Defaults to the driver-self path. The owner-self-
+   * driver flow (OO completing their own self-driver record from inside the
+   * owner dashboard) passes /api/submit-self-driver-profile instead.
+   */
+  endpoint?: string;
 }
 
-export function DriverProfileCompletion({ driverId, onComplete }: DriverProfileCompletionProps) {
+export function DriverProfileCompletion({
+  driverId,
+  onComplete,
+  endpoint = '/api/submit-driver-profile',
+}: DriverProfileCompletionProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [coiData, setCoiData] = useState<COIData>({});
   const { toast } = useToast();
@@ -143,10 +153,11 @@ export function DriverProfileCompletion({ driverId, onComplete }: DriverProfileC
         coiPolicyNumber: coiData.policyNumber,
       });
 
-      const response = await fetch('/api/submit-driver-profile', {
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          driverId,
           profileData: {
             dateOfBirth: values.dateOfBirth,
             cdlNumber: values.cdlNumber,


### PR DESCRIPTION
## Summary
When an OO uses **Add Self as Driver**, the resulting driver record sits forever on the compliance scorecard's "Attestations — Pending: Driver Authorization & Disclosure — awaiting profile submission" line, because the full driver-side profile (DOB / CDL / medical / authorization consent) is never collected for them. The existing `/api/submit-driver-profile` endpoint assumes the calling user *is* the driver (driver doc id = `user.uid`), which doesn't hold for self-driver records (auto-generated doc id).

This PR adds a path for the OO to complete their own driver profile from inside the owner dashboard, which then captures the authorization consent and flips the scorecard to "Verified".

## Changes
- **New endpoint** — `src/app/api/submit-self-driver-profile/route.ts`. Authenticates the caller as the owner via the `fb-id-token` cookie, then writes to `owner_operators/{caller.uid}/drivers/{driverId}` **only if** that driver doc has `isSelfDriver === true`. Mirrors the field-name normalization (`medicalCertExpiration → medicalCardExpiry`), consent IP/device-info enhancement, and audit logging (`AuditActions.DRIVER_PROFILE_SUBMITTED`) of the original endpoint. Skips the owner-notification email since the owner *is* the submitter.
- **`src/components/driver-profile-completion.tsx`** — accepts an optional `endpoint` prop (defaults to the existing `/api/submit-driver-profile` so the driver-dashboard flow is unchanged). Always includes `driverId` in the request body so the new endpoint can target the correct doc.
- **`src/app/dashboard/drivers/page.tsx`** — on the OO's own self-driver detail view, a banner `Alert` with a **Complete Driver Profile** button appears when `isSelfDriver === true` AND `profileStatus ∉ {'pending_confirmation','complete'}` AND `profileComplete !== true`. Clicking opens a `Sheet` hosting `<DriverProfileCompletion endpoint="/api/submit-self-driver-profile" driverId={selectedDriver.id} />`. On successful submit, the sheet closes and the detail view refreshes — `profileStatus` flips to `pending_confirmation`, `driverConsents.driverAuthorization` is recorded, and the compliance scorecard "Attestations" section turns green.

## Setup Required
- None.

## Test Plan
- [ ] As an OO who hasn't yet self-added: add yourself as a driver. Open your own driver detail view. The new "Your driver profile is incomplete…" Alert with **Complete Driver Profile** button is visible.
- [ ] Click **Complete Driver Profile**. The sheet opens with the full DOB / CDL / medical / endorsements / authorization form.
- [ ] Submit the form. Confirm the toast says "Profile Submitted! Awaiting fleet confirmation."
- [ ] The detail view's compliance scorecard "Attestations" section now reads **Verified — signed at profile submission**.
- [ ] Firestore: `owner_operators/{ownerUid}/drivers/{driverId}` has the new field values (DOB, CDL, medicalCardExpiry, endorsements), `profileStatus: 'pending_confirmation'`, `driverConsents.driverAuthorization` populated with IP + device info.
- [ ] Audit log has a `DRIVER_PROFILE_SUBMITTED` event with `userRole: 'owner_operator'` and `metadata.selfDriver: true`.
- [ ] Driver-dashboard flow for a *normal* invited driver is unaffected (`/driver-dashboard/complete-profile` still works and uses the original endpoint).
- [ ] Security: a non-owner who tries to POST `/api/submit-self-driver-profile` with someone else's driverId gets 404/403 ("Driver document not found" or "Driver is not a self-driver record").
- [ ] No console errors on any of the flows above.

> Targets `qa` per the CLAUDE.md default. I'll merge after this is opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_