### PR TITLE
feat(attestations): post-onboarding recapture for missing driver + profile attestations + load-post gate

### DIFF
--- a/src/app/api/append-attestations/route.ts
+++ b/src/app/api/append-attestations/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { handleApiError, handleApiSuccess } from '@/lib/api-error-handler';
+import { withCors } from '@/lib/api-cors';
+import { ATTESTATIONS, type AttestationType } from '@/lib/attestations';
+import { logAuditEvent, AuditActions } from '@/lib/audit-logger';
+
+const LOG_PREFIX = '[append-attestations]';
+
+// Recapturable attestation surfaces. Locked allowlist — other surfaces
+// (match_confirm_*, tla, post_trip) have their own dedicated flows and
+// should not be writable here.
+const ALLOWED_TYPES = new Set<AttestationType>([
+  // surface: 'driver_add'
+  'driverDqf',
+  'driverFmcsaChecks',
+  'driverAuthority',
+  // surface: 'profile'
+  'profileInsurance',
+  'profileAuthority',
+]);
+
+const bodySchema = z.object({
+  types: z.array(z.string()).min(1, 'at least one attestation type required'),
+  driverId: z.string().min(1).optional(),
+  deviceInfo: z.record(z.any()).optional(),
+});
+
+async function verifyToken(auth: any, tokenValue: string) {
+  try {
+    return await auth.verifySessionCookie(tokenValue, true);
+  } catch {
+    return await auth.verifyIdToken(tokenValue);
+  }
+}
+
+async function handlePost(req: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+    const token = req.cookies.get('fb-id-token');
+    if (!token) throw new Error('Unauthorized');
+
+    const owner = await verifyToken(auth, token.value);
+
+    const body = await req.json();
+    const validation = bodySchema.safeParse(body);
+    if (!validation.success) {
+      const errs = Object.values(validation.error.flatten().fieldErrors).flat().join(', ');
+      throw new Error(errs || 'Invalid request body');
+    }
+    const { types, driverId, deviceInfo } = validation.data;
+
+    const valid = types.filter((t): t is AttestationType =>
+      ALLOWED_TYPES.has(t as AttestationType),
+    );
+    if (valid.length === 0) {
+      throw new Error('No allowed attestation types in request');
+    }
+
+    // Surface integrity: driver_add types require a driverId; profile types
+    // must NOT have one. Mixing them in a single call is rejected.
+    const hasDriverTypes = valid.some(t => ATTESTATIONS[t].surface === 'driver_add');
+    const hasProfileTypes = valid.some(t => ATTESTATIONS[t].surface === 'profile');
+    if (hasDriverTypes && hasProfileTypes) {
+      throw new Error('Cannot mix driver_add and profile attestations in one call');
+    }
+    if (hasDriverTypes && !driverId) {
+      throw new Error('driverId is required for driver_add attestations');
+    }
+    if (hasProfileTypes && driverId) {
+      throw new Error('driverId must be omitted for profile attestations');
+    }
+
+    // If this is a driver_add call, verify the driver doc exists under this
+    // owner — no cross-owner writes.
+    if (hasDriverTypes) {
+      const driverRef = db
+        .collection('owner_operators')
+        .doc(owner.uid)
+        .collection('drivers')
+        .doc(driverId!);
+      const driverDoc = await driverRef.get();
+      if (!driverDoc.exists()) {
+        throw new Error('Driver document not found');
+      }
+    }
+
+    const ipAddress =
+      req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || 'unknown';
+    const userAgent = req.headers.get('user-agent') || undefined;
+    const acceptedAt = new Date().toISOString();
+
+    const entries = valid.map(type => {
+      const def = ATTESTATIONS[type];
+      return {
+        type,
+        version: def.v,
+        text: def.text,
+        acceptedAt,
+        acceptedBy: owner.uid,
+        ip: ipAddress,
+        userAgent,
+        ...(hasDriverTypes
+          ? { context: { driverId, ...(deviceInfo ? { deviceInfo } : {}) } }
+          : deviceInfo
+            ? { context: { deviceInfo } }
+            : {}),
+      };
+    });
+
+    const ownerRef = db.collection('owner_operators').doc(owner.uid);
+    await ownerRef.update({
+      attestations: FieldValue.arrayUnion(...entries),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    console.log(
+      `${LOG_PREFIX} Appended ${entries.length} attestation(s) for owner ${owner.uid}` +
+        (driverId ? `, driver ${driverId}` : '') +
+        `: ${valid.join(', ')}`,
+    );
+
+    await logAuditEvent({
+      action: AuditActions.DRIVER_PROFILE_SUBMITTED,
+      userId: owner.uid,
+      userRole: 'owner_operator',
+      targetId: driverId || owner.uid,
+      targetType: hasDriverTypes ? 'driver' : 'owner_operator',
+      metadata: {
+        attestationRecapture: true,
+        surface: hasDriverTypes ? 'driver_add' : 'profile',
+        types: valid,
+      },
+      ipAddress,
+      userAgent,
+    });
+
+    return handleApiSuccess({
+      success: true,
+      captured: valid,
+      message: `Captured ${valid.length} attestation(s).`,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`${LOG_PREFIX} Error:`, errorMessage, error);
+    if (errorMessage === 'Unauthorized') {
+      return handleApiError(
+        'unauthorized',
+        error instanceof Error ? error : new Error(errorMessage),
+        { endpoint: 'POST /api/append-attestations' },
+      );
+    }
+    return handleApiError(
+      'server',
+      error instanceof Error ? error : new Error(errorMessage),
+      { endpoint: 'POST /api/append-attestations' },
+    );
+  }
+}
+
+export const POST = withCors(handlePost);

--- a/src/app/dashboard/drivers/page.tsx
+++ b/src/app/dashboard/drivers/page.tsx
@@ -20,6 +20,8 @@ import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescri
 import { AddDriverForm } from "@/components/add-driver-form";
 import { AddSelfAsDriverButton } from "@/components/add-self-as-driver-button";
 import { DriverProfileCompletion } from "@/components/driver-profile-completion";
+import { AttestationRecaptureSheet } from "@/components/attestation-recapture-sheet";
+import { ATTESTATIONS, hasCurrent, type AttestationEntry, type AttestationType } from "@/lib/attestations";
 import { EditDriverModal } from "@/components/edit-driver-modal";
 import { DriverStatusBadge } from "@/components/driver-status-badge";
 import { DriverConfirmationCard } from "@/components/driver-confirmation-card";
@@ -204,6 +206,9 @@ export default function DriversPage() {
   const [togglingDriver, setTogglingDriver] = useState<Driver | null>(null);
   const [isToggling, setIsToggling] = useState(false);
   const [completeSelfProfileOpen, setCompleteSelfProfileOpen] = useState(false);
+  const [recaptureAttestationsOpen, setRecaptureAttestationsOpen] = useState(false);
+  const [ownerAttestations, setOwnerAttestations] = useState<AttestationEntry[]>([]);
+  const [attestationRefreshKey, setAttestationRefreshKey] = useState(0);
   // OO doc — fetched once so FMCSA section gets real DOT/MC numbers
   const [ooDoc, setOoDoc] = useState<Partial<OwnerOperator> | undefined>(undefined);
   const { user, isUserLoading } = useUser();
@@ -218,23 +223,27 @@ export default function DriversPage() {
     return () => { window.removeEventListener('online', handleOnline); window.removeEventListener('offline', handleOffline); };
   }, []);
 
-  // Fetch OO doc once user is ready so we can pass dotNumber/mcNumber to FMCSA section
+  // Fetch OO doc once user is ready so we can pass dotNumber/mcNumber to FMCSA
+  // section AND surface ownerAttestations (used to detect missing per-driver
+  // attestations on the driver detail view). Re-runs when attestationRefreshKey
+  // bumps, so the recapture flow can refresh without a page reload.
   useEffect(() => {
     async function fetchOO() {
       if (!firestore || !user?.uid) return;
       try {
         const snap = await getDoc(doc(firestore, 'owner_operators', user.uid));
         if (snap.exists()) {
-          const data = snap.data() as OwnerOperator;
+          const data = snap.data() as OwnerOperator & { attestations?: AttestationEntry[] };
           setOoDoc({ dotNumber: data.dotNumber, mcNumber: data.mcNumber });
-          console.log(`${LOG_PREFIX} OO doc loaded: dotNumber=${data.dotNumber}, mcNumber=${data.mcNumber}`);
+          setOwnerAttestations(Array.isArray(data.attestations) ? data.attestations : []);
+          console.log(`${LOG_PREFIX} OO doc loaded: dotNumber=${data.dotNumber}, mcNumber=${data.mcNumber}, attestations=${(data.attestations || []).length}`);
         }
       } catch (err) {
         console.warn(`${LOG_PREFIX} Failed to fetch OO doc:`, err);
       }
     }
     fetchOO();
-  }, [firestore, user?.uid]);
+  }, [firestore, user?.uid, attestationRefreshKey]);
 
   const driversQuery = useMemoFirebase(() => {
     if (!firestore || !user?.uid) return null;
@@ -413,6 +422,27 @@ export default function DriversPage() {
           </Alert>
         )}
 
+        {(() => {
+          const recapturable: AttestationType[] = ['driverDqf', 'driverFmcsaChecks', 'driverAuthority'];
+          const missing = recapturable.filter(
+            t => !hasCurrent(ownerAttestations, t, { driverId: selectedDriver.id }),
+          );
+          if (missing.length === 0) return null;
+          return (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <span>
+                  Missing per-driver attestation{missing.length === 1 ? '' : 's'} for this driver: <strong>{missing.join(', ')}</strong>. Capture them to clear the audit gap.
+                </span>
+                <Button size="sm" variant="outline" onClick={() => setRecaptureAttestationsOpen(true)}>
+                  Capture missing attestations
+                </Button>
+              </AlertDescription>
+            </Alert>
+          );
+        })()}
+
         <Separator />
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -506,6 +536,20 @@ export default function DriversPage() {
             </SheetContent>
           </Sheet>
         )}
+
+        <AttestationRecaptureSheet
+          candidateTypes={['driverDqf', 'driverFmcsaChecks', 'driverAuthority']}
+          missingTypes={(['driverDqf', 'driverFmcsaChecks', 'driverAuthority'] as AttestationType[]).filter(
+            t => !hasCurrent(ownerAttestations, t, { driverId: selectedDriver.id }),
+          )}
+          driverId={selectedDriver.id}
+          contextLabel={`Driver: ${selectedDriver.name || selectedDriver.id}`}
+          title="Capture Missing Driver Attestations"
+          description="Confirm the per-driver compliance attestations below. Each entry is appended to your owner record with this driver as context."
+          open={recaptureAttestationsOpen}
+          onOpenChange={setRecaptureAttestationsOpen}
+          onCaptured={() => setAttestationRefreshKey(k => k + 1)}
+        />
       </div>
     );
   }

--- a/src/app/dashboard/loads/new/page.tsx
+++ b/src/app/dashboard/loads/new/page.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useUser, useFirestore } from '@/firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import { hasCurrent, type AttestationEntry, type AttestationType } from '@/lib/attestations';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -56,11 +59,39 @@ type Step = 'form' | 'review';
 
 export default function PostLoadPage() {
   const router = useRouter();
+  const { user } = useUser();
+  const db = useFirestore();
   const [step, setStep] = useState<Step>('form');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCalculatingRoute, setIsCalculatingRoute] = useState(false);
   const [routePreview, setRoutePreview] = useState<RoutePreview | null>(null);
   const [routeError, setRouteError] = useState<string | null>(null);
+
+  // Gate: profile-level attestations must be current before posting a load.
+  // States: 'checking' until the owner doc fetch resolves, then 'blocked' if
+  // profileInsurance or profileAuthority is missing, otherwise 'ok'.
+  const [gateState, setGateState] = useState<'checking' | 'blocked' | 'ok'>('checking');
+  const [missingProfileAttestations, setMissingProfileAttestations] = useState<AttestationType[]>([]);
+
+  useEffect(() => {
+    async function checkProfileAttestations() {
+      if (!user || !db) return;
+      try {
+        const snap = await getDoc(doc(db, 'owner_operators', user.uid));
+        const data = snap.exists() ? (snap.data() as { attestations?: AttestationEntry[] }) : {};
+        const required: AttestationType[] = ['profileInsurance', 'profileAuthority'];
+        const missing = required.filter(t => !hasCurrent(data.attestations, t));
+        setMissingProfileAttestations(missing);
+        setGateState(missing.length > 0 ? 'blocked' : 'ok');
+      } catch (err) {
+        console.warn('[PostLoadPage] failed to verify profile attestations', err);
+        // Fail-open: don't lock the user out on a fetch error. The downstream
+        // server-side gates (Firestore rules / API checks) remain authoritative.
+        setGateState('ok');
+      }
+    }
+    checkProfileAttestations();
+  }, [user, db]);
 
   const [formData, setFormData] = useState({
     origin: '',
@@ -261,6 +292,42 @@ export default function PostLoadPage() {
               <Button variant="outline" onClick={() => handleSubmit('draft')} disabled={isSubmitting}>
                 <Save className="h-4 w-4 mr-2" />Save as Draft
               </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (gateState === 'checking') {
+    return (
+      <div className="container max-w-4xl py-8 flex items-center justify-center min-h-[40vh]">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (gateState === 'blocked') {
+    return (
+      <div className="container max-w-4xl py-8">
+        <div className="mb-6">
+          <Link href="/dashboard/loads"><Button variant="outline" size="sm"><ArrowLeft className="h-4 w-4 mr-2" />Back to Loads</Button></Link>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-2xl font-headline">Complete Your Profile First</CardTitle>
+            <CardDescription>Posting a load requires your company-level compliance attestations to be on file.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Missing profile attestation{missingProfileAttestations.length === 1 ? '' : 's'}: <strong>{missingProfileAttestations.join(', ')}</strong>. Capture them on your profile page, then come back to post a load.
+              </AlertDescription>
+            </Alert>
+            <div className="flex gap-2">
+              <Link href="/dashboard/profile"><Button>Go to Profile</Button></Link>
+              <Link href="/dashboard/loads"><Button variant="outline">Cancel</Button></Link>
             </div>
           </CardContent>
         </Card>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -29,7 +29,9 @@ import { showSuccess, showError } from '@/lib/toast-utils';
 import { parseError } from '@/lib/error-utils';
 import { format, parseISO } from 'date-fns';
 import type { FMCSACarrier } from '@/lib/fmcsa';
-import { ATTESTATIONS, type AttestationEntry } from '@/lib/attestations';
+import { ATTESTATIONS, hasCurrent, type AttestationEntry, type AttestationType } from '@/lib/attestations';
+import { AttestationRecaptureSheet } from '@/components/attestation-recapture-sheet';
+import { AlertCircle } from 'lucide-react';
 
 interface COIInfo {
   fileUrl?: string;
@@ -115,6 +117,8 @@ export default function ProfilePage() {
 
   const [coiInsurerName, setCoiInsurerName] = useState('');
   const [coiPolicyNumber, setCoiPolicyNumber] = useState('');
+  const [profileAttestationsSheetOpen, setProfileAttestationsSheetOpen] = useState(false);
+  const [attestationRefreshTick, setAttestationRefreshTick] = useState(0);
   const [coiExpiryDate, setCoiExpiryDate] = useState('');
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -171,7 +175,7 @@ export default function ProfilePage() {
       }
     }
     if (user && db) loadProfile();
-  }, [user, db]);
+  }, [user, db, attestationRefreshTick]);
 
   // Read lock state from the edited profile so the "Change DOT" action
   // (which sets editedProfile.fmcsaVerified = false) immediately unlocks
@@ -491,6 +495,37 @@ export default function ProfilePage() {
         <h1 className="text-2xl font-bold">Company Profile</h1>
         <p className="text-muted-foreground">View and manage your company information, insurance, and compliance status.</p>
       </div>
+
+      {(() => {
+        const candidates: AttestationType[] = ['profileInsurance', 'profileAuthority'];
+        const missing = candidates.filter(t => !hasCurrent(profile?.attestations, t));
+        if (missing.length === 0) return null;
+        return (
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+              <span>
+                Profile attestations missing: <strong>{missing.join(', ')}</strong>. These gate access to posting loads and confirming matches &mdash; capture them now.
+              </span>
+              <Button size="sm" onClick={() => setProfileAttestationsSheetOpen(true)}>
+                Capture profile attestations
+              </Button>
+            </AlertDescription>
+          </Alert>
+        );
+      })()}
+
+      <AttestationRecaptureSheet
+        candidateTypes={['profileInsurance', 'profileAuthority']}
+        missingTypes={(['profileInsurance', 'profileAuthority'] as AttestationType[]).filter(
+          t => !hasCurrent(profile?.attestations, t),
+        )}
+        title="Capture Profile Attestations"
+        description="These statements apply to the company / owner level. They gate marketplace access (load posting, match confirmation)."
+        open={profileAttestationsSheetOpen}
+        onOpenChange={setProfileAttestationsSheetOpen}
+        onCaptured={() => setAttestationRefreshTick(t => t + 1)}
+      />
 
       <Card>
         <CardHeader>

--- a/src/components/attestation-recapture-sheet.tsx
+++ b/src/components/attestation-recapture-sheet.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import { showSuccess, showError } from '@/lib/toast-utils';
+import { ATTESTATIONS, type AttestationType } from '@/lib/attestations';
+
+interface AttestationRecaptureSheetProps {
+  /** Attestation types eligible for capture in this sheet (allowlist). */
+  candidateTypes: AttestationType[];
+  /** Subset of candidateTypes that are currently MISSING and should be capturable. */
+  missingTypes: AttestationType[];
+  /** Optional context — required for driver_add types, omitted for profile types. */
+  driverId?: string;
+  /** Free-form context label rendered in the sheet header. */
+  contextLabel?: string;
+  title: string;
+  description: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCaptured?: () => void;
+}
+
+export function AttestationRecaptureSheet({
+  candidateTypes,
+  missingTypes,
+  driverId,
+  contextLabel,
+  title,
+  description,
+  open,
+  onOpenChange,
+  onCaptured,
+}: AttestationRecaptureSheetProps) {
+  const [checked, setChecked] = useState<Set<AttestationType>>(new Set(missingTypes));
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setChecked(new Set(missingTypes));
+    }
+  }, [open, missingTypes]);
+
+  function toggle(type: AttestationType) {
+    setChecked(prev => {
+      const copy = new Set(prev);
+      if (copy.has(type)) {
+        copy.delete(type);
+      } else {
+        copy.add(type);
+      }
+      return copy;
+    });
+  }
+
+  async function handleSubmit() {
+    if (checked.size === 0) {
+      showError('Select at least one attestation to capture.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/append-attestations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          types: Array.from(checked),
+          ...(driverId ? { driverId } : {}),
+          deviceInfo: {
+            userAgent: navigator.userAgent,
+            language: navigator.language,
+            platform: navigator.platform,
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data?.error || 'Failed to capture attestations');
+      }
+      showSuccess(`Captured ${(data.captured || []).length} attestation(s).`);
+      onOpenChange(false);
+      onCaptured?.();
+    } catch (e: any) {
+      console.error('[AttestationRecaptureSheet] submit error', e);
+      showError(e?.message || 'Failed to capture attestations.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>
+            {description}
+            {contextLabel && (
+              <>
+                {' '}
+                <strong>{contextLabel}</strong>
+              </>
+            )}
+          </SheetDescription>
+        </SheetHeader>
+
+        <Alert className="mt-4">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Only check items that are accurate right now. Recording an attestation
+            you can&apos;t back up creates compliance and legal exposure.
+          </AlertDescription>
+        </Alert>
+
+        <div className="mt-6 space-y-4">
+          {candidateTypes.map(type => {
+            const isMissing = missingTypes.includes(type);
+            const def = ATTESTATIONS[type];
+            return (
+              <div
+                key={type}
+                className={`flex items-start gap-3 rounded-md border p-3 ${isMissing ? '' : 'opacity-60'}`}
+              >
+                <Checkbox
+                  id={`attest-${type}`}
+                  checked={checked.has(type)}
+                  onCheckedChange={() => toggle(type)}
+                  disabled={!isMissing || submitting}
+                  className="mt-1"
+                />
+                <div className="space-y-1">
+                  <Label htmlFor={`attest-${type}`} className="cursor-pointer text-sm font-medium">
+                    {type}
+                    {!isMissing && (
+                      <span className="ml-2 text-xs text-muted-foreground">(already on file)</span>
+                    )}
+                  </Label>
+                  <p className="text-xs text-muted-foreground leading-relaxed">{def.text}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <SheetFooter className="mt-6">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting || checked.size === 0}>
+            {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Capture {checked.size > 0 ? `(${checked.size})` : ''}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary
Two post-onboarding attestation-recapture surfaces, in one PR. Together they close the audit-gap problem where an OO who skipped (or never reached) a blocking attestation has no way to get back to it.

1. **Per-driver recapture** — banner on the driver detail view when `driverDqf` / `driverFmcsaChecks` / `driverAuthority` is missing for that driver.
2. **Profile-level recapture** — banner on `/dashboard/profile` when `profileInsurance` / `profileAuthority` is missing, **plus** a load-post gate at `/dashboard/loads/new` that blocks the page with a CTA to the profile if either is missing.

## Changes
- **New endpoint** `src/app/api/append-attestations/route.ts` — generalized append endpoint backed by `arrayUnion` on `owner_operators/{ownerUid}.attestations`. Locked allowlist (`driverDqf`, `driverFmcsaChecks`, `driverAuthority`, `profileInsurance`, `profileAuthority`). Surface integrity rules:
  - `driver_add` types require `driverId` AND the driver doc exist under the caller (no cross-owner writes).
  - `profile` types must NOT have a `driverId`.
  - Mixing surfaces in one request is rejected.
  - Snapshots IP, userAgent, deviceInfo; uses registry-current `v` and `text`; emits an audit-log event with `metadata.attestationRecapture: true` and the surface name.
- **New component** `src/components/attestation-recapture-sheet.tsx` — reusable Sheet rendering missing attestations as labeled checkboxes (with the registry's exact text). Already-on-file items are visible but disabled. Submits to `/api/append-attestations`.
- **`src/app/dashboard/drivers/page.tsx`** — driver detail view: detects missing per-driver attestations against the owner's `attestations[]` via `hasCurrent(_, type, {driverId})`. Banner + sheet wired. Owner attestations re-fetched on capture so the banner clears immediately. Also keeps the existing self-driver "Complete Driver Profile" banner shipped in #154.
- **`src/app/dashboard/profile/page.tsx`** — top-of-page banner when `profileInsurance` / `profileAuthority` missing. Profile is reloaded on capture so both the banner and the "Attestations on File" section update.
- **`src/app/dashboard/loads/new/page.tsx`** — mounts a profile-attestation gate. While checking, a spinner; if missing, a blocking "Complete Your Profile First" card with a CTA to `/dashboard/profile`; if complete, the existing load form. **Fail-open** on fetch errors — server-side Firestore rules / API checks remain the authoritative boundary, this is a UX gate only.

## Setup Required
- None.

## Test Plan
- [ ] On QA as an OO with a driver where one or more of `driverDqf` / `driverFmcsaChecks` / `driverAuthority` is missing: open `/dashboard/drivers` → driver detail. New banner "Missing per-driver attestation(s)…" is visible. Click → sheet opens with the right items pre-checked. Submit → toast confirms, banner disappears, Compliance Scorecard "Attestations" section updates.
- [ ] On QA as an OO missing `profileInsurance` or `profileAuthority`: open `/dashboard/profile`. New banner near the top is visible with the missing types listed. Click → sheet → submit → toast, banner disappears, "Attestations on File" section reflects the new entries.
- [ ] On QA as the same OO (still missing profile attestations): open `/dashboard/loads/new`. The page renders the **"Complete Your Profile First"** blocking card with a CTA to `/dashboard/profile` and a Cancel back to `/dashboard/loads`. The load form does NOT render.
- [ ] After capturing both profile attestations, revisit `/dashboard/loads/new` — load form now renders normally.
- [ ] Network failure path: throttle/break Firestore network temporarily, hit `/dashboard/loads/new`. Page should still render the load form (fail-open), and a server-side write would still be gated by Firestore rules.
- [ ] Owner whose `attestations[]` has older `v` entries: `hasCurrent` returns false on bump, banner appears. After recapture the new `v` entry coexists with the old one (append-only audit trail).
- [ ] Security: a non-owner who POSTs `/api/append-attestations` with a `driverId` belonging to someone else gets "Driver document not found".
- [ ] No console errors / no hydration warnings on any of the above surfaces.

> Targets `qa` per the CLAUDE.md default. Will merge after open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_