### PR TITLE
fix(qa): TLA focus + signup session + load date/list + legacy address (5 bugs)

### DIFF
--- a/src/app/create-profile/page.tsx
+++ b/src/app/create-profile/page.tsx
@@ -1,46 +1,23 @@
 'use client';
 
 import Link from 'next/link';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
 import { CompanyProfileForm } from '@/components/company-profile-form';
 import { Logo } from '@/components/logo';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { useUser, useFirestore } from '@/firebase';
-import { doc, updateDoc } from 'firebase/firestore';
 import { Loader2, Building2 } from 'lucide-react';
 
 function CreateProfileContent() {
   const searchParams = useSearchParams();
-  const router = useRouter();
   const error = searchParams.get('error');
-  const { user } = useUser();
-  const db = useFirestore();
-
-  const handleSkip = async () => {
-    if (!user || !db) {
-      router.push('/dashboard');
-      return;
-    }
-    try {
-      await updateDoc(doc(db, 'owner_operators', user.uid), {
-        'onboardingStatus.profileSkipped': true,
-        'onboardingStatus.profileSkippedAt': new Date().toISOString(),
-      });
-    } catch (e) {
-      console.error('Failed to save skip status:', e);
-    }
-    router.push('/dashboard');
-  };
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
@@ -68,11 +45,6 @@ function CreateProfileContent() {
           )}
           <CompanyProfileForm />
         </CardContent>
-        <CardFooter className="flex-col items-center justify-center">
-          <Button variant="link" className="text-muted-foreground" onClick={handleSkip}>
-            Skip for now
-          </Button>
-        </CardFooter>
       </Card>
     </div>
   );

--- a/src/app/dashboard/loads/new/page.tsx
+++ b/src/app/dashboard/loads/new/page.tsx
@@ -219,9 +219,14 @@ export default function PostLoadPage() {
     } finally { setIsSubmitting(false); }
   };
 
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const minDate = tomorrow.toISOString().split('T')[0];
+  // Earliest allowed pickup date is today (same-day pickups are valid).
+  // Build the YYYY-MM-DD string from local-time components so a late-evening
+  // user in a western timezone doesn't get bumped to tomorrow by UTC offset.
+  const _today = new Date();
+  const _yyyy = _today.getFullYear();
+  const _mm = String(_today.getMonth() + 1).padStart(2, '0');
+  const _dd = String(_today.getDate()).padStart(2, '0');
+  const minDate = `${_yyyy}-${_mm}-${_dd}`;
   const getLoadTypeLabel = (v: string) => LOAD_TYPES.find(t => t.value === v)?.label || v;
   const getTrailerTypeLabel = (v: string) => TRAILER_TYPES.find(t => t.value === v)?.label || v;
 

--- a/src/app/dashboard/loads/page.tsx
+++ b/src/app/dashboard/loads/page.tsx
@@ -54,7 +54,24 @@ export default function LoadsPage() {
   const [deleteTarget, setDeleteTarget] = useState<Load | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  useEffect(() => { fetchLoads(); }, []);
+  // Refetch on mount AND whenever the tab regains focus / becomes visible
+  // again — without this, a load posted from /dashboard/loads/new doesn't
+  // show up after navigating back, because the page is still rendering the
+  // initial fetch's empty state.
+  useEffect(() => {
+    fetchLoads();
+    const onFocus = () => fetchLoads();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') fetchLoads();
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const fetchLoads = async () => {
     try {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -114,19 +114,15 @@ function RegisterContent() {
         });
 
         const token = await newUser.getIdToken();
-        
+
         // POST session cookie and WAIT for it to complete before redirecting.
-        // This ensures the fb-id-token cookie is set before the server action
-        // in /create-profile tries to authenticate via authenticateServerAction().
-        const response = await fetch('/api/auth/session', {
+        // This sets the fb-id-token cookie that the server action behind the
+        // CompanyProfileForm relies on.
+        const sessionResponse = await fetch('/api/auth/session', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ token }),
         });
-
-        if (!response.ok) {
-          throw new Error('Failed to create session');
-        }
 
         // Send welcome email fire-and-forget — do NOT await
         fetch('/api/send-welcome-email', {
@@ -135,13 +131,26 @@ function RegisterContent() {
           body: JSON.stringify({ email: newUser.email, companyName }),
         }).catch(err => console.error('Failed to send welcome email:', err));
 
+        if (!sessionResponse.ok) {
+          // The Firebase Auth user + Firestore docs were written successfully,
+          // we just couldn't establish a session cookie (rate limit, transient
+          // infra, etc.). Don't show a generic red error — the account exists.
+          // Bounce the user to the login page so they can sign in cleanly.
+          console.warn('[register] Session POST failed after successful account creation', sessionResponse.status);
+          showSuccess('Account created. Please sign in to continue.');
+          router.push(`/login?email=${encodeURIComponent(newUser.email || '')}&message=Account created. Please log in to continue.`);
+          return;
+        }
+
         showSuccess('Account created successfully!');
 
-        // Small settle delay to ensure the cookie is readable by middleware
-        // before the navigation triggers a server-side read.
-        await new Promise(resolve => setTimeout(resolve, 150));
-        router.push('/create-profile');
-        
+        // Hard navigation (window.location.href) instead of router.push so the
+        // next request carries the freshly-Set-Cookie'd fb-id-token in its
+        // request headers — soft client-side navigation can race the browser
+        // cookie write and result in the server action seeing no cookie.
+        window.location.href = '/create-profile';
+        return;
+
       } else {
         throw new Error("Database service is not available.");
       }

--- a/src/components/company-profile-form.tsx
+++ b/src/components/company-profile-form.tsx
@@ -85,7 +85,27 @@ export function CompanyProfileForm() {
           if (data.hqCity) form.setValue('hqCity', data.hqCity);
           if (data.hqState) form.setValue('hqState', data.hqState);
           if (data.hqZip) form.setValue('hqZip', data.hqZip);
-          if (!data.hqStreet && data.hqAddress) form.setValue('hqStreet', data.hqAddress);
+          // Legacy migration: older accounts only had data.hqAddress as a
+          // single comma-separated string. Try to split it into Street /
+          // City / State / Zip so the form's individual fields populate
+          // instead of dumping the entire address into the Street input.
+          // Expected shape: "Street, City, ST 12345" (FMCSA-style).
+          if (!data.hqStreet && !data.hqCity && !data.hqState && !data.hqZip && data.hqAddress) {
+            const legacy = String(data.hqAddress).trim();
+            // Match trailing "ST 12345" (or 12345-1234 ZIP+4)
+            const cszMatch = legacy.match(/^(.*),\s*([A-Za-z][A-Za-z\s.'-]+),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)\s*$/);
+            if (cszMatch) {
+              const [, streetPart, cityPart, statePart, zipPart] = cszMatch;
+              form.setValue('hqStreet', streetPart.trim());
+              form.setValue('hqCity', cityPart.trim());
+              form.setValue('hqState', statePart.toUpperCase());
+              form.setValue('hqZip', zipPart);
+            } else {
+              // Could not parse confidently — leave Street populated so the
+              // user can see what was on file and re-enter the split.
+              form.setValue('hqStreet', legacy);
+            }
+          }
           if (data.operatingStates?.length) form.setValue('operatingStates', data.operatingStates);
           if (data.coi) setCoiData(data.coi);
           if (data.fmcsaVerified) {

--- a/src/components/tla/TLASignForm.tsx
+++ b/src/components/tla/TLASignForm.tsx
@@ -43,6 +43,99 @@ interface TLASignFormProps {
   onSignSuccess: (updatedTLA: TLA) => void;
 }
 
+// IMPORTANT: this component MUST stay at module scope.
+// Declaring it inside TLASignForm's function body would create a new
+// component reference on every parent render, which React then remounts —
+// which would destroy input focus on every keystroke.
+function LocationFields({
+  title,
+  location,
+  setLocation,
+  showContact = true,
+}: {
+  title: string;
+  location: LocationData;
+  setLocation: (loc: LocationData) => void;
+  showContact?: boolean;
+}) {
+  return (
+    <div className="space-y-3 p-4 bg-muted/30 rounded-lg">
+      <h4 className="font-medium flex items-center gap-2">
+        <MapPin className="h-4 w-4" />
+        {title}
+      </h4>
+
+      <div className="space-y-2">
+        <Label>Street Address *</Label>
+        <Input
+          placeholder="123 Main St, Suite 100"
+          value={location.address}
+          onChange={(e) => setLocation({ ...location, address: e.target.value })}
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div className="space-y-2">
+          <Label>City *</Label>
+          <Input
+            placeholder="City"
+            value={location.city}
+            onChange={(e) => setLocation({ ...location, city: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>State *</Label>
+          <Input
+            placeholder="TX"
+            maxLength={2}
+            value={location.state}
+            onChange={(e) => setLocation({ ...location, state: e.target.value.toUpperCase() })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>ZIP *</Label>
+          <Input
+            placeholder="12345"
+            value={location.zip}
+            onChange={(e) => setLocation({ ...location, zip: e.target.value })}
+          />
+        </div>
+      </div>
+
+      {showContact && (
+        <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-2">
+            <Label>Contact Name</Label>
+            <Input
+              placeholder="John Doe"
+              value={location.contactName || ""}
+              onChange={(e) => setLocation({ ...location, contactName: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Contact Phone</Label>
+            <Input
+              placeholder="(555) 123-4567"
+              value={location.contactPhone || ""}
+              onChange={(e) => setLocation({ ...location, contactPhone: e.target.value })}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Special Instructions</Label>
+        <Textarea
+          placeholder="Dock number, gate code, delivery hours, etc."
+          value={location.instructions || ""}
+          onChange={(e) => setLocation({ ...location, instructions: e.target.value })}
+          rows={2}
+        />
+      </div>
+    </div>
+  );
+}
+
 export function TLASignForm({ tla, tlaId, signingRole, onSignSuccess }: TLASignFormProps) {
   const { user } = useUser();
   const firestore = useFirestore();
@@ -195,93 +288,6 @@ export function TLASignForm({ tla, tlaId, signingRole, onSignSuccess }: TLASignF
       setIsSigning(false);
     }
   };
-
-  const LocationFields = ({
-    title,
-    location,
-    setLocation,
-    showContact = true,
-  }: {
-    title: string;
-    location: LocationData;
-    setLocation: (loc: LocationData) => void;
-    showContact?: boolean;
-  }) => (
-    <div className="space-y-3 p-4 bg-muted/30 rounded-lg">
-      <h4 className="font-medium flex items-center gap-2">
-        <MapPin className="h-4 w-4" />
-        {title}
-      </h4>
-
-      <div className="space-y-2">
-        <Label>Street Address *</Label>
-        <Input
-          placeholder="123 Main St, Suite 100"
-          value={location.address}
-          onChange={(e) => setLocation({ ...location, address: e.target.value })}
-        />
-      </div>
-
-      <div className="grid grid-cols-3 gap-2">
-        <div className="space-y-2">
-          <Label>City *</Label>
-          <Input
-            placeholder="City"
-            value={location.city}
-            onChange={(e) => setLocation({ ...location, city: e.target.value })}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>State *</Label>
-          <Input
-            placeholder="TX"
-            maxLength={2}
-            value={location.state}
-            onChange={(e) => setLocation({ ...location, state: e.target.value.toUpperCase() })}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>ZIP *</Label>
-          <Input
-            placeholder="12345"
-            value={location.zip}
-            onChange={(e) => setLocation({ ...location, zip: e.target.value })}
-          />
-        </div>
-      </div>
-
-      {showContact && (
-        <div className="grid grid-cols-2 gap-2">
-          <div className="space-y-2">
-            <Label>Contact Name</Label>
-            <Input
-              placeholder="John Doe"
-              value={location.contactName || ""}
-              onChange={(e) => setLocation({ ...location, contactName: e.target.value })}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Contact Phone</Label>
-            <Input
-              placeholder="(555) 123-4567"
-              value={location.contactPhone || ""}
-              onChange={(e) => setLocation({ ...location, contactPhone: e.target.value })}
-            />
-          </div>
-        </div>
-      )}
-
-      <div className="space-y-2">
-        <Label>Special Instructions</Label>
-        <Textarea
-          placeholder="Dock number, gate code, delivery hours, etc."
-          value={location.instructions || ""}
-          onChange={(e) => setLocation({ ...location, instructions: e.target.value })}
-          rows={2}
-        />
-      </div>
-    </div>
-  );
 
   return (
     <Card>


### PR DESCRIPTION
## Summary
Bundled fix for 5 of the 10 bugs from your QA testing session. Each is verified against the code; #5 and #6 are deliberately not in this PR (see Notes).

## Fixes
- **#10 — TLA inputs lose focus after each keystroke.** Root cause: `LocationFields` was declared inside `TLASignForm`'s function body, so every parent render created a new component reference and React remounted the subtree — destroying input focus. Hoisted `LocationFields` to module scope. Fix touches `src/components/tla/TLASignForm.tsx`.
- **#1/#2/#3 — Owner signup flow.** Three connected fixes in `src/app/register/page.tsx` and `src/app/create-profile/page.tsx`:
  1. When `/api/auth/session` POST 4xx's after a successful Firebase user creation, **don't show the generic red "failed" banner**. The account exists; we now route the user to `/login?email=…&message=Account created. Please log in.` with a success toast.
  2. On success, swap `router.push('/create-profile')` for `window.location.href = '/create-profile'`. The hard navigation makes the next request carry the freshly-Set-Cookie'd `fb-id-token` — soft client-side navigation was racing the cookie write, which made the server action behind `CompanyProfileForm` see no cookie and emit a `NEXT_REDIRECT` back to `/login`. The driver-register flow was already doing this; owner-register was the one that wasn't.
  3. Removed the **"Skip for now"** button on `/create-profile`. Brand-new accounts shouldn't be able to bypass onboarding and land on `/dashboard`.
- **#4 — Load `pickupDate` rejected today.** `src/app/dashboard/loads/new/page.tsx:222` was setting `minDate` to **tomorrow**. Changed to today, computed from local components so a late-evening user in a western TZ doesn't get bumped to tomorrow by UTC offset.
- **#7 — Legacy `hqAddress` dumped into the Street field.** `src/components/company-profile-form.tsx:88`. Added a regex split for the FMCSA-canonical shape `"Street, City, ST 12345"` (also accepts ZIP+4) when the split fields are all empty. If the regex can't parse, we still drop the legacy value in Street so the user can see what was on file and re-enter the split.
- **#9 — Loads posted from `/new` don't show on the list after navigating back.** `src/app/dashboard/loads/page.tsx:57` was a one-shot `useEffect`. Added `window 'focus'` + `document 'visibilitychange'` listeners that refetch when the tab returns. Lightweight; doesn't introduce a real-time Firestore subscription.

## Not in this PR (need more info)
- **#5 sparkle on driver register form** — scanned the entire `src/` for U+2728 and any decorative emoji range, no sparkle in the source. Need a screenshot of where it's rendering to track it down.
- **#6 driver CDL/Auth submission failure** — three likely failure modes in `/api/submit-driver-profile` (`Owner not found`, `Driver document not found`, `Unauthorized`). Need the exact network response / browser console error to nail which one.

## Setup Required
- None.

## Test Plan
- [ ] **#10 TLA focus**: open a TLA pending lessee signature, focus the Delivery Street Address input, type a long string. The input keeps focus; you don't have to re-click between characters. Same for Pickup and Truck Return inputs.
- [ ] **#1/#2/#3 happy path**: sign up a new owner account on QA. You land on `/create-profile` (not bounced to `/login`). Submitting the profile form there doesn't kick you to `/login` either.
- [ ] **#1 sad path**: simulate session-cookie POST failure (Chrome DevTools → block `/api/auth/session`). After signup, you see "Account created. Please sign in." and land on `/login` — **no red "failed" banner**. Logging in works because the Firebase user actually exists.
- [ ] **#2 skip path is gone**: confirm `/create-profile` has no "Skip for now" link any more.
- [ ] **#4 date picker**: open `/dashboard/loads/new`, click Pickup Date — today is selectable.
- [ ] **#7 address parsing**: as an existing legacy owner whose Firestore doc has only `hqAddress` (single string in FMCSA format), open `/dashboard/profile` — Street / City / State / Zip are populated separately, not all dumped into Street.
- [ ] **#9 loads refresh**: post a load. After redirect, the new load is visible on the list. Switching tabs / minimizing and coming back also refetches.
- [ ] Regression: existing TLA flow, driver register flow, and dashboard navigation are unaffected.

> Targets `qa` per the CLAUDE.md default. Merging after this is opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_