### PR TITLE
fix(matches): include 'live'/'match_pending' loads in Find Match filters

### DIFF
--- a/src/app/dashboard/matches/page.tsx
+++ b/src/app/dashboard/matches/page.tsx
@@ -83,11 +83,18 @@ export default function MatchesPage() {
   const { user } = useUser();
   const firestore = useFirestore();
 
-  // Subscribe to MY pending loads
+  // Subscribe to MY pending loads.
+  // "Pending" is the legacy status string; the current /api/loads POST
+  // writes "live" by default and bumps to "match_pending" once a match
+  // request goes out. Both new statuses plus the legacy one should
+  // populate this panel so newly-posted loads show up immediately.
   useEffect(() => {
     if (!firestore || !user?.uid) return;
     const unsubscribe = onSnapshot(
-      query(collection(firestore, `owner_operators/${user.uid}/loads`), where("status", "==", "Pending")),
+      query(
+        collection(firestore, `owner_operators/${user.uid}/loads`),
+        where("status", "in", ["Pending", "live", "match_pending"]),
+      ),
       (snapshot) => {
         const loads = snapshot.docs.map((d) => ({ ...d.data(), id: d.id } as Load));
         setMyPendingLoads(loads);
@@ -99,16 +106,19 @@ export default function MatchesPage() {
     return () => unsubscribe();
   }, [firestore, user?.uid]);
 
-  // Subscribe to ALL pending loads
+  // Subscribe to ALL pending loads. Mirrors the my-pending status set
+  // ("Pending" legacy + "live" + "match_pending" current) so newly-posted
+  // loads from other owners are also matchable.
   useEffect(() => {
     if (!firestore || !user?.uid) return;
+    const AVAILABLE_STATUSES = new Set(['Pending', 'live', 'match_pending']);
     const unsubscribe = onSnapshot(
       collectionGroup(firestore, "loads"),
       (snapshot) => {
         const loads: LoadWithOwner[] = [];
         snapshot.docs.forEach((docSnap) => {
           const data = docSnap.data() as Load;
-          if (data.status !== "Pending") return;
+          if (!AVAILABLE_STATUSES.has(data.status as string)) return;
           const ownerId = docSnap.ref.path.split("/")[1];
           loads.push({ ...data, id: docSnap.id, ownerId });
         });


### PR DESCRIPTION
## Summary
Find Match's **My Assets** panel doesn't include newly-posted loads even when those loads are marked Live on the `/dashboard/loads` list.

## Root cause
`src/app/dashboard/matches/page.tsx` had two Firestore subscriptions filtering for `status === "Pending"`:
- **Line 90** — `where("status", "==", "Pending")` (Firestore-side filter on my loads).
- **Line 111** — `if (data.status !== "Pending") return;` (client-side filter on the cross-owner `collectionGroup`).

But the current `/api/loads` POST writes `status: 'live'` by default (per the Zod schema enum in `src/app/api/loads/route.ts`) and the match-request flow bumps it to `match_pending`. Neither matches `"Pending"`, so brand-new loads silently fail the filter. The 9 loads that *do* show in the screenshot are legacy data still tagged `"Pending"`.

## Fix
Widen both filters to the set `{"Pending", "live", "match_pending"}`:
- My loads: `where("status", "in", ["Pending", "live", "match_pending"])`.
- All loads: a `Set`-membership check on the cross-owner snapshot.

Keeping `"Pending"` in the list means no migration is needed for legacy data — they continue to surface.

## Setup Required
- None.

## Test Plan
- [ ] On QA: post a brand-new load via `/dashboard/loads/new`. Navigate to `/dashboard/matches` → My Assets → My Loads. The new load is now visible alongside any legacy loads.
- [ ] Existing legacy `"Pending"` loads still surface (no regression).
- [ ] On another owner's account, the cross-owner "all pending loads" view also includes the newly-posted load (collection-group subscription).
- [ ] Once a match request is created and a load transitions to `match_pending`, it stays visible in the My Assets panel.

> Targets `qa` per the CLAUDE.md default. Merging after this is opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_