### PR TITLE
feat(matching): PR 1 transparency sprint — soft equipment + diagnostic panel + reweight

### DIFF
--- a/src/app/dashboard/matches/page.tsx
+++ b/src/app/dashboard/matches/page.tsx
@@ -31,6 +31,7 @@ import { collection, query, where, collectionGroup, doc, getDoc, onSnapshot } fr
 import {
   findMatchingDrivers,
   findMatchingLoads,
+  findIneligibleDrivers,
   getMatchQualityLabel,
   getMatchReasons,
   type MatchScore,
@@ -227,13 +228,30 @@ export default function MatchesPage() {
     setSelectionMode(null);
   };
 
-  const driverMatches =
+  // Pool of drivers eligible for the selected load (excluding own fleet
+  // + inactive). Same input feeds both findMatchingDrivers (ranking) and
+  // findIneligibleDrivers (diagnostic panel).
+  const driverPoolForLoad =
     selectedLoad && selectionMode === "load" && allDrivers.length > 0
+      ? allDrivers.filter((d) => d.ownerId !== user?.uid && d.isActive !== false)
+      : [];
+
+  const driverMatches =
+    selectedLoad && selectionMode === "load" && driverPoolForLoad.length > 0
       ? findMatchingDrivers(
           selectedLoad,
-          allDrivers.filter((d) => d.ownerId !== user?.uid && d.isActive !== false),
+          driverPoolForLoad,
           { onlyGreenCompliance: true, onlyAvailable: true, maxResults: 10 }
         )
+      : [];
+
+  // PR 1 transparency: drivers that were filtered out of the ranking
+  // because of hard-eligibility checks (availability / expired docs).
+  // Equipment is now a SOFT scoring penalty, not a hard filter, so wrong-
+  // equipment drivers appear in driverMatches with a low score, not here.
+  const ineligibleDriversForLoad =
+    selectedLoad && selectionMode === "load" && driverPoolForLoad.length > 0
+      ? findIneligibleDrivers(driverPoolForLoad, { onlyGreenCompliance: true, onlyAvailable: true })
       : [];
 
   const loadMatches =
@@ -363,7 +381,7 @@ export default function MatchesPage() {
             </CardTitle>
             <CardDescription className="truncate text-xs md:text-sm">
               {selectionMode === "load" && selectedLoad
-                ? `Top drivers for your load to ${selectedLoad.destination}`
+                ? `Best of ${driverMatches.length} eligible driver${driverMatches.length === 1 ? "" : "s"} for ${selectedLoad.destination}${ineligibleDriversForLoad.length > 0 ? ` (${ineligibleDriversForLoad.length} filtered out — see below)` : ""}`
                 : selectionMode === "driver" && selectedMyDriver
                   ? `Top loads for ${selectedMyDriver.name}`
                   : "Select your load or driver from My Assets"}
@@ -477,12 +495,54 @@ export default function MatchesPage() {
                           </Card>
                         );
                       })}
+
+                      {ineligibleDriversForLoad.length > 0 && (
+                        <div className="mt-6 border rounded-lg p-3 md:p-4 bg-muted/30">
+                          <h4 className="text-sm font-semibold mb-2 flex items-center gap-2">
+                            <Users className="h-4 w-4 text-muted-foreground" />
+                            Drivers filtered out
+                            <span className="text-xs font-normal text-muted-foreground">
+                              ({ineligibleDriversForLoad.length})
+                            </span>
+                          </h4>
+                          <p className="text-xs text-muted-foreground mb-3">
+                            These drivers in the pool were excluded by hard-eligibility checks (availability or expired documents). Equipment is no longer a hard filter — wrong-equipment drivers appear in the ranked list above with a low score.
+                          </p>
+                          <ul className="space-y-1.5">
+                            {ineligibleDriversForLoad.slice(0, 10).map(({ driver, reason }) => (
+                              <li key={driver.id || driver.name} className="text-xs flex items-start gap-2">
+                                <span className="font-medium">{driver.name}</span>
+                                <span className="text-muted-foreground">— {reason}</span>
+                              </li>
+                            ))}
+                            {ineligibleDriversForLoad.length > 10 && (
+                              <li className="text-xs text-muted-foreground italic">
+                                …and {ineligibleDriversForLoad.length - 10} more.
+                              </li>
+                            )}
+                          </ul>
+                        </div>
+                      )}
                     </div>
                   ) : (
                     <div className="flex flex-col items-center justify-center h-64 text-center p-4 border-2 border-dashed rounded-lg">
                       <Users className="h-12 w-12 text-muted-foreground" />
                       <h3 className="mt-4 text-base font-semibold font-headline">No Matching Drivers</h3>
-                      <p className="mt-2 text-sm text-muted-foreground">No available drivers match this load.</p>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {ineligibleDriversForLoad.length > 0
+                          ? `${ineligibleDriversForLoad.length} driver${ineligibleDriversForLoad.length === 1 ? " was" : "s were"} filtered out — see reasons below.`
+                          : "No available drivers in the pool."}
+                      </p>
+                      {ineligibleDriversForLoad.length > 0 && (
+                        <ul className="mt-4 text-left text-xs space-y-1.5 max-w-md w-full">
+                          {ineligibleDriversForLoad.slice(0, 10).map(({ driver, reason }) => (
+                            <li key={driver.id || driver.name} className="flex items-start gap-2">
+                              <span className="font-medium">{driver.name}</span>
+                              <span className="text-muted-foreground">— {reason}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                     </div>
                   )
                 ) : selectionMode === "driver" && selectedMyDriver ? (

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -58,15 +58,30 @@ const DEFAULT_OPTIONS: MatchingOptions = {
 };
 
 // ---------------------------------------------------------------------------
-// Scoring weights (DEV-123)
-// Total: 100 pts
+// Scoring weights — total: 100 pts
+// PR 1 (transparency sprint) reweight:
+//   - Equipment dropped from 20 → 10 because it's now a soft scoring penalty
+//     rather than a hard filter (wrong-equipment drivers still appear in
+//     results, just ranked lower).
+//   - Rating bumped from 5 → 10 because the previous 5 was noise — couldn't
+//     distinguish a 4.9 from a 3.2 driver in any meaningful way.
+//   - Location bumped from 35 → 40 to keep the total at 100 and give a
+//     small additional weight to proximity, the most operationally
+//     significant factor after compliance.
+//   - Qualification (40) unchanged — compliance is the largest single bucket.
 // ---------------------------------------------------------------------------
 const WEIGHTS = {
-  location: 35,
-  vehicle: 20,
+  location: 40,
+  vehicle: 10,
   qualification: 40,  // blended qual+compliance
-  rating: 5,
+  rating: 10,
 } as const;
+
+// Multiplier applied to the vehicle bucket when the driver's trailer doesn't
+// match the load's required trailerType. Keeps wrong-equipment drivers in
+// results (so the OO sees them) but pushes them well below correct-equipment
+// candidates.
+const WRONG_EQUIPMENT_MULTIPLIER = 0.2;
 
 const EXPIRY_WARNING_DAYS = 30;
 
@@ -82,9 +97,16 @@ const VEHICLE_CARGO_SYNONYMS: Record<string, string[]> = {
   tanker: ["tank", "liquid", "bulk liquid"],
   hopper: ["grain", "bulk", "dry bulk"],
   lowboy: ["low boy", "low-boy", "heavy haul", "heavy equipment"],
-  "step deck": ["step-deck", "stepdeck", "drop deck"],
+  "step deck": ["step-deck", "stepdeck", "drop deck", "drop-deck"],
   conestoga: ["curtain side", "curtainside"],
   hazmat: ["hazardous", "hazardous materials", "dangerous goods"],
+  // PR 1 — added trailer types that were silently failing equipment match
+  // because the only mapping was the in-code constant.
+  "auto carrier": ["auto-carrier", "car hauler", "car-hauler", "car carrier", "vehicle carrier"],
+  "power only": ["power-only", "poweronly", "tractor only", "bobtail"],
+  rgn: ["removable gooseneck", "removable-gooseneck"],
+  "double drop": ["double-drop", "doubledrop"],
+  livestock: ["cattle", "animal hauler"],
 };
 
 function getSynonyms(term: string): string[] {
@@ -439,10 +461,15 @@ function buildBreakdown(
   load: Load,
   locationScore: number
 ): MatchScoreBreakdown {
-  // Vehicle match (0-20)
+  // Vehicle match (0-WEIGHTS.vehicle).
+  // PR 1: equipment is now a SOFT penalty, not a hard filter. Wrong-equipment
+  // drivers still appear in results — they just get the WRONG_EQUIPMENT_MULTIPLIER
+  // share of this bucket so they rank well below correct-equipment candidates.
   let vehicleMatch = 0;
   if (load.trailerType) {
-    vehicleMatch = WEIGHTS.vehicle; // hard filter already verified compatibility
+    vehicleMatch = isEquipmentCompatible(driver, load)
+      ? WEIGHTS.vehicle
+      : Math.round(WEIGHTS.vehicle * WRONG_EQUIPMENT_MULTIPLIER);
   } else if (load.requiredQualifications && load.requiredQualifications.length > 0) {
     const driverTypes = getDriverTrailerTypes(driver);
     const matches = load.requiredQualifications.some((req) =>
@@ -518,17 +545,9 @@ export function findMatchingDrivers(
 ): MatchScore[] {
   const opts = { ...DEFAULT_OPTIONS, ...options };
 
-  const eligible = drivers.filter((driver) => {
-    if (opts.onlyAvailable && driver.availability !== "Available") return false;
-    if (opts.onlyGreenCompliance) {
-      // Still use the lightweight status check as a hard gate
-      const expiryDetails = buildExpiryDetails(driver);
-      const hasExpired = expiryDetails.some((d) => d.status === "expired");
-      if (hasExpired) return false;
-    }
-    if (!isEquipmentCompatible(driver, load)) return false;
-    return true;
-  });
+  // PR 1: equipment is no longer a hard filter — it falls through to scoring.
+  // The remaining hard filters are availability + expired compliance docs.
+  const eligible = drivers.filter((driver) => filterEligibility(driver, opts) === null);
 
   console.log(
     `${LOG_PREFIX} findMatchingDrivers: ${eligible.length}/${drivers.length} eligible for load ${load.id ?? load.origin}`
@@ -546,6 +565,45 @@ export function findMatchingDrivers(
   return opts.maxResults ? scored.slice(0, opts.maxResults) : scored;
 }
 
+// Returns the reason a driver fails hard-eligibility checks, or null if
+// they're eligible. Used both by findMatchingDrivers and the new
+// findIneligibleDrivers helper so the two stay in lockstep.
+function filterEligibility(driver: Driver, opts: MatchingOptions): string | null {
+  if (opts.onlyAvailable && driver.availability !== "Available") {
+    return `Not available (${driver.availability || "no status"})`;
+  }
+  if (opts.onlyGreenCompliance) {
+    const expiryDetails = buildExpiryDetails(driver);
+    const expired = expiryDetails.filter((d) => d.status === "expired");
+    if (expired.length > 0) {
+      return `Expired: ${expired.map((d) => d.label).join(", ")}`;
+    }
+  }
+  return null;
+}
+
+export interface IneligibleDriver {
+  driver: Driver;
+  reason: string;
+}
+
+// Mirror of findMatchingDrivers that returns the drivers who were *excluded*
+// by the hard-eligibility checks, with the reason for each exclusion. The
+// matches page renders this as a diagnostic panel so OOs can see why a
+// driver they expected to appear was filtered out.
+export function findIneligibleDrivers(
+  drivers: Driver[],
+  options: MatchingOptions = {}
+): IneligibleDriver[] {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const out: IneligibleDriver[] = [];
+  for (const driver of drivers) {
+    const reason = filterEligibility(driver, opts);
+    if (reason) out.push({ driver, reason });
+  }
+  return out;
+}
+
 export async function findMatchingDriversAsync(
   load: Load,
   drivers: Driver[],
@@ -553,14 +611,8 @@ export async function findMatchingDriversAsync(
 ): Promise<MatchScore[]> {
   const opts = { ...DEFAULT_OPTIONS, ...options };
 
-  const eligible = drivers.filter((driver) => {
-    if (opts.onlyAvailable && driver.availability !== "Available") return false;
-    if (opts.onlyGreenCompliance) {
-      const expiryDetails = buildExpiryDetails(driver);
-      if (expiryDetails.some((d) => d.status === "expired")) return false;
-    }
-    return true;
-  });
+  // PR 1: same eligibility helper as findMatchingDrivers.
+  const eligible = drivers.filter((driver) => filterEligibility(driver, opts) === null);
 
   const scored: MatchScore[] = await Promise.all(
     eligible.map(async (driver) => {
@@ -576,6 +628,12 @@ export async function findMatchingDriversAsync(
   return opts.maxResults ? scored.slice(0, opts.maxResults) : scored;
 }
 
+// PR 1: equipment is a soft penalty here too; the only hard filter on a load
+// is that its status is in the available-for-matching set. The legacy
+// "Pending" string is kept alongside the current "live" / "match_pending"
+// so old data continues to surface.
+const AVAILABLE_LOAD_STATUSES = new Set(['Pending', 'live', 'match_pending']);
+
 export function findMatchingLoads(
   driver: Driver,
   loads: Load[],
@@ -583,15 +641,13 @@ export function findMatchingLoads(
 ): LoadMatchScore[] {
   const { maxResults = 10 } = options;
 
-  const compatible = loads.filter(
-    (load) => load.status === "Pending" && isEquipmentCompatible(driver, load)
-  );
+  const available = loads.filter((load) => AVAILABLE_LOAD_STATUSES.has(load.status as string));
 
   console.log(
-    `${LOG_PREFIX} findMatchingLoads: ${compatible.length}/${loads.length} compatible for driver ${driver.id ?? driver.name}`
+    `${LOG_PREFIX} findMatchingLoads: ${available.length}/${loads.length} available for driver ${driver.id ?? driver.name}`
   );
 
-  const scored = compatible.map((load) => {
+  const scored = available.map((load) => {
     const breakdown = calculateMatchScore(driver, load);
     const score = getTotalScore(breakdown);
     return { load, score, breakdown, rank: 0, isBestMatch: false };


### PR DESCRIPTION
## Summary
PR 1 of 3 for the matching algorithm rework (transparency sprint). Same surface — algorithm + Find Match UI — and the highest-leverage bundle. Directly resolves the "Miami drivers don't appear for the Tampa load" bug.

## Changes

### 1. Equipment is now a soft scoring penalty (not a hard filter)
- `matching.ts:findMatchingDrivers` / `findMatchingDriversAsync` / `findMatchingLoads` no longer drop drivers whose trailer doesn't match `load.trailerType`.
- `matching.ts:buildBreakdown` awards full `WEIGHTS.vehicle` when compatible, `WEIGHTS.vehicle * 0.2` when not. Wrong-equipment drivers still appear in results — they rank well below correct-equipment candidates instead of vanishing.

### 2. Reweighted (total stays 100)
| Bucket | Before | After | Why |
|---|---|---|---|
| Qualification + compliance | 40 | 40 | unchanged |
| Location / distance | 35 | **40** | rebalance to keep total at 100 |
| Equipment | 20 | **10** | now a penalty bucket, not a hard filter |
| Rating | 5 | **10** | 5 was noise — couldn't differentiate a 4.9 from a 3.2 |

### 3. New `findIneligibleDrivers` helper + diagnostic panel
- `matching.ts:findIneligibleDrivers` returns drivers excluded by the remaining hard filters (availability + expired docs) with a per-driver reason string. Shared internal `filterEligibility()` keeps the eligible / ineligible lists in lockstep with `findMatchingDrivers`.
- `src/app/dashboard/matches/page.tsx` renders the result below the Ranked Matches list as **"Drivers filtered out (N)"** with each driver's reason ("Not available (Off-duty)" / "Expired: CDL, Medical Certificate" / etc.). If the eligible list is empty *and* there are filtered drivers, the empty-state explains why instead of just saying "No Matching Drivers".

### 4. "Best of N candidates" framing
- Ranked Matches `CardDescription` now reads `"Best of N eligible drivers for <destination> (M filtered out — see below)"` instead of `"Top drivers for your load to <destination>"`. Tells the OO whether the list is the full universe or the survivors.

### 5. Synonym table extensions
- Added `auto carrier` / `car hauler` / `car-hauler` / `car carrier` / `vehicle carrier`; `power-only` variants; `rgn`; `double drop`; `livestock`. Also expanded step-deck variants (`drop-deck`).
- This is the temporary in-code patch. The Firestore-backed trailer-type collection ships in PR 2.

### 6. `findMatchingLoads` status filter fix
- Was hard-coded to `load.status === "Pending"` which silently excluded current-schema loads (`status: 'live'` / `'match_pending'`). Now uses the same status set we use in the matches subscription (PR #157).

## Not in this PR (deferred)
- **PR 2** — Firestore-backed trailer-type collection (admin-editable, no more code deploys for new synonyms) + Radar API geocoding replacing the 80-city dictionary.
- **PR 3** — Pickup-window feasibility check (HOS + travel time vs pickup deadline). Depends on PR 2's real geocoding.

## Setup Required
- None.

## Test Plan
- [ ] **Repro case from chat**: Post a Tampa→Atlanta load with trailerType `"Auto Carrier"`. Select it on `/dashboard/matches`. The Miami dry-van drivers (Carlos / John Smith) now appear in the ranked list with a *lower* score (vehicleMatch is 2/10, not 10/10). They're no longer silently filtered.
- [ ] **Diagnostic panel**: Put a driver into the pool with availability `"Off-duty"`. Select a load. The driver appears in "Drivers filtered out (N)" below Ranked Matches with reason "Not available (Off-duty)".
- [ ] **Expired docs**: Set a driver's `cdlExpiry` to a past date. Verify they show up under "Drivers filtered out" with reason "Expired: CDL".
- [ ] **Best-of-N framing**: The Ranked Matches header should read "Best of 3 eligible drivers for Atlanta (2 filtered out — see below)" when 5 drivers are in the pool with 2 ineligible.
- [ ] **Synonym table**: A driver tagged `"car hauler"` matches a load with `trailerType: "Auto Carrier"`. Equipment full points.
- [ ] **Reweight regression check**: Confirm a top driver (correct equipment, close location, current docs, 4.5 rating) still scores in the "Excellent" range (≥80). The math: 40 location + 10 equipment + 40 qual + 9 rating = 99/100.
- [ ] No console errors / no hydration warnings on `/dashboard/matches`.

> Targets `qa` per the CLAUDE.md default. Merging after this is opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_