### PR TITLE
feat(matching): PR 3 — pickup-window feasibility check (miles vs time-until-pickup)

### DIFF
--- a/src/app/dashboard/matches/page.tsx
+++ b/src/app/dashboard/matches/page.tsx
@@ -440,10 +440,22 @@ export default function MatchesPage() {
                         const companyName = match.driver.ownerId ? ownerNames[match.driver.ownerId] : null;
                         const hasWarning = !!match.breakdown.qualificationWarning;
                         return (
-                          <Card key={match.driver.id} className={`shadow-none overflow-hidden ${match.isBestMatch ? "ring-2 ring-primary" : ""}`}>
+                          <Card key={match.driver.id} className={`shadow-none overflow-hidden ${match.isBestMatch ? "ring-2 ring-primary" : ""} ${match.breakdown.feasibility?.feasible === false ? "opacity-70" : ""}`}>
                             {match.isBestMatch && (
                               <div className="bg-primary text-primary-foreground px-3 py-1.5 flex items-center gap-2 text-sm font-medium">
                                 <Trophy className="h-4 w-4" />Best Match
+                              </div>
+                            )}
+                            {match.breakdown.feasibility?.feasible === false && (
+                              <div className="bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-300 border-b border-red-200 dark:border-red-900 px-3 py-1.5 flex items-center gap-2 text-xs font-medium">
+                                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+                                Cannot make pickup in time{match.breakdown.feasibility.reason ? ` — ${match.breakdown.feasibility.reason}` : ""}
+                              </div>
+                            )}
+                            {match.breakdown.feasibility?.feasible === true && match.breakdown.feasibility.tightSchedule && (
+                              <div className="bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300 border-b border-amber-200 dark:border-amber-900 px-3 py-1.5 flex items-center gap-2 text-xs font-medium">
+                                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+                                Tight pickup window{match.breakdown.feasibility.reason ? ` — ${match.breakdown.feasibility.reason}` : ""}
                               </div>
                             )}
                             <CardHeader className="pb-2">

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -20,6 +20,25 @@ export interface MatchScoreBreakdown {
   qualificationWarning?: string;
   // Individual expiry details for the Learn More panel
   expiryDetails?: ExpiryDetail[];
+  // PR 3: pickup-window feasibility (can the driver physically reach the
+  // load origin by the pickup deadline?). Computed when both endpoints
+  // geocode AND the load has a usable pickupDate. Otherwise undefined.
+  feasibility?: PickupFeasibility;
+}
+
+export interface PickupFeasibility {
+  /** False = physically can't make the pickup window. */
+  feasible: boolean;
+  /** True when feasible but cutting it close (>70% of available time). */
+  tightSchedule: boolean;
+  /** Estimated deadhead miles (driver location → load origin). */
+  estimatedMiles?: number;
+  /** Estimated travel hours including HOS buffer. */
+  estimatedTravelHours?: number;
+  /** Hours between "now" and the pickup deadline (end of pickupDate). */
+  hoursUntilPickup?: number;
+  /** Human-readable explanation when infeasible / tight. */
+  reason?: string;
 }
 
 export interface ExpiryDetail {
@@ -464,13 +483,99 @@ function calculateQualificationScore(
 }
 
 // ---------------------------------------------------------------------------
+// PR 3: pickup-window feasibility
+//
+// Rough estimate of whether a driver can physically reach the load origin
+// before the pickup deadline. NOT a full HOS model — that requires actual
+// duty status, recent off-duty hours, and 11-hour driving limit tracking
+// we don't have today. This is a sanity check that catches the obvious
+// "NYC driver for a Tampa pickup in 4 hours" failure mode.
+//
+//   avg highway speed     = 50 mph
+//   pickup deadline       = end of pickupDate (local-time approximation)
+//   HOS sleep buffer      = +10 hours when > 600 miles of deadhead
+//
+// If we lack any of: driver coords, load coords, parseable pickupDate —
+// we return undefined and skip the feasibility signal entirely.
+// ---------------------------------------------------------------------------
+
+const AVG_HIGHWAY_MPH = 50;
+const HOS_SLEEP_THRESHOLD_MI = 600;
+const HOS_SLEEP_BUFFER_HOURS = 10;
+const TIGHT_SCHEDULE_RATIO = 0.7;
+
+function computePickupFeasibility(
+  driverCoords: { lat: number; lng: number } | null,
+  loadCoords: { lat: number; lng: number } | null,
+  pickupDate: string | undefined,
+): PickupFeasibility | undefined {
+  if (!driverCoords || !loadCoords || !pickupDate) return undefined;
+
+  let deadlineMs: number;
+  try {
+    // Treat pickupDate as the local-day deadline. We give the driver until
+    // 23:59 local on the pickup date to arrive. Construct in local time
+    // explicitly so we don't fight TZ offsets.
+    const [yyyy, mm, dd] = pickupDate.split('-').map((s) => parseInt(s, 10));
+    if (!yyyy || !mm || !dd) return undefined;
+    const deadline = new Date(yyyy, mm - 1, dd, 23, 59, 59, 0);
+    deadlineMs = deadline.getTime();
+    if (!Number.isFinite(deadlineMs)) return undefined;
+  } catch {
+    return undefined;
+  }
+
+  const nowMs = Date.now();
+  const hoursUntilPickup = (deadlineMs - nowMs) / (1000 * 60 * 60);
+  const miles = calculateDistance(driverCoords.lat, driverCoords.lng, loadCoords.lat, loadCoords.lng);
+  const baseHours = miles / AVG_HIGHWAY_MPH;
+  const sleepBuffer = miles > HOS_SLEEP_THRESHOLD_MI ? HOS_SLEEP_BUFFER_HOURS : 0;
+  const estimatedTravelHours = baseHours + sleepBuffer;
+
+  if (hoursUntilPickup <= 0) {
+    return {
+      feasible: false,
+      tightSchedule: false,
+      estimatedMiles: Math.round(miles),
+      estimatedTravelHours: Math.round(estimatedTravelHours * 10) / 10,
+      hoursUntilPickup: Math.round(hoursUntilPickup * 10) / 10,
+      reason: 'Pickup date has already passed',
+    };
+  }
+
+  if (estimatedTravelHours > hoursUntilPickup) {
+    return {
+      feasible: false,
+      tightSchedule: false,
+      estimatedMiles: Math.round(miles),
+      estimatedTravelHours: Math.round(estimatedTravelHours * 10) / 10,
+      hoursUntilPickup: Math.round(hoursUntilPickup * 10) / 10,
+      reason: `~${Math.round(estimatedTravelHours)}h drive vs ${Math.round(hoursUntilPickup)}h until pickup`,
+    };
+  }
+
+  const tight = estimatedTravelHours > TIGHT_SCHEDULE_RATIO * hoursUntilPickup;
+  return {
+    feasible: true,
+    tightSchedule: tight,
+    estimatedMiles: Math.round(miles),
+    estimatedTravelHours: Math.round(estimatedTravelHours * 10) / 10,
+    hoursUntilPickup: Math.round(hoursUntilPickup * 10) / 10,
+    reason: tight
+      ? `Tight: ~${Math.round(estimatedTravelHours)}h drive vs ${Math.round(hoursUntilPickup)}h available`
+      : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Core breakdown calculator
 // ---------------------------------------------------------------------------
 
 function buildBreakdown(
   driver: Driver,
   load: Load,
-  locationScore: number
+  locationScore: number,
+  feasibility?: PickupFeasibility,
 ): MatchScoreBreakdown {
   // Vehicle match (0-WEIGHTS.vehicle).
   // PR 1: equipment is now a SOFT penalty, not a hard filter. Wrong-equipment
@@ -516,6 +621,7 @@ function buildBreakdown(
     complianceScore: 0, // folded into qualificationScore — kept at 0 for compat
     qualificationWarning: warning,
     expiryDetails,
+    feasibility,
   };
 }
 
@@ -526,13 +632,15 @@ function buildBreakdown(
 export function calculateMatchScore(driver: Driver, load: Load): MatchScoreBreakdown {
   const dCoords = getCoordinatesSync(driver.location || "");
   const lCoords = getCoordinatesSync(load.origin || "");
-  return buildBreakdown(driver, load, calculateLocationScoreWeighted(dCoords, lCoords));
+  const feasibility = computePickupFeasibility(dCoords, lCoords, load.pickupDate);
+  return buildBreakdown(driver, load, calculateLocationScoreWeighted(dCoords, lCoords), feasibility);
 }
 
 export async function calculateMatchScoreAsync(driver: Driver, load: Load): Promise<MatchScoreBreakdown> {
   const dCoords = await getCoordinatesAsync(driver.location || "");
   const lCoords = await getCoordinatesAsync(load.origin || "");
-  return buildBreakdown(driver, load, calculateLocationScoreWeighted(dCoords, lCoords));
+  const feasibility = computePickupFeasibility(dCoords, lCoords, load.pickupDate);
+  return buildBreakdown(driver, load, calculateLocationScoreWeighted(dCoords, lCoords), feasibility);
 }
 
 export function getTotalScore(breakdown: MatchScoreBreakdown): number {
@@ -570,8 +678,15 @@ export function findMatchingDrivers(
     return { driver, score, breakdown, rank: 0, isBestMatch: false };
   });
 
-  scored.sort((a, b) => b.score - a.score);
-  scored.forEach((m, i) => { m.rank = i + 1; m.isBestMatch = i === 0; });
+  // PR 3: infeasible-by-schedule drivers always sort below feasible ones,
+  // regardless of raw score. Within each group we sort by score descending.
+  scored.sort((a, b) => {
+    const aInfeasible = a.breakdown.feasibility?.feasible === false ? 1 : 0;
+    const bInfeasible = b.breakdown.feasibility?.feasible === false ? 1 : 0;
+    if (aInfeasible !== bInfeasible) return aInfeasible - bInfeasible;
+    return b.score - a.score;
+  });
+  scored.forEach((m, i) => { m.rank = i + 1; m.isBestMatch = i === 0 && m.breakdown.feasibility?.feasible !== false; });
 
   return opts.maxResults ? scored.slice(0, opts.maxResults) : scored;
 }
@@ -633,8 +748,15 @@ export async function findMatchingDriversAsync(
     })
   );
 
-  scored.sort((a, b) => b.score - a.score);
-  scored.forEach((m, i) => { m.rank = i + 1; m.isBestMatch = i === 0; });
+  // PR 3: infeasible-by-schedule drivers always sort below feasible ones,
+  // regardless of raw score. Within each group we sort by score descending.
+  scored.sort((a, b) => {
+    const aInfeasible = a.breakdown.feasibility?.feasible === false ? 1 : 0;
+    const bInfeasible = b.breakdown.feasibility?.feasible === false ? 1 : 0;
+    if (aInfeasible !== bInfeasible) return aInfeasible - bInfeasible;
+    return b.score - a.score;
+  });
+  scored.forEach((m, i) => { m.rank = i + 1; m.isBestMatch = i === 0 && m.breakdown.feasibility?.feasible !== false; });
 
   return opts.maxResults ? scored.slice(0, opts.maxResults) : scored;
 }
@@ -664,8 +786,15 @@ export function findMatchingLoads(
     return { load, score, breakdown, rank: 0, isBestMatch: false };
   });
 
-  scored.sort((a, b) => b.score - a.score);
-  scored.forEach((m, i) => { m.rank = i + 1; m.isBestMatch = i === 0; });
+  // PR 3: infeasible-by-schedule drivers always sort below feasible ones,
+  // regardless of raw score. Within each group we sort by score descending.
+  scored.sort((a, b) => {
+    const aInfeasible = a.breakdown.feasibility?.feasible === false ? 1 : 0;
+    const bInfeasible = b.breakdown.feasibility?.feasible === false ? 1 : 0;
+    if (aInfeasible !== bInfeasible) return aInfeasible - bInfeasible;
+    return b.score - a.score;
+  });
+  scored.forEach((m, i) => { m.rank = i + 1; m.isBestMatch = i === 0 && m.breakdown.feasibility?.feasible !== false; });
 
   return scored.slice(0, maxResults);
 }


### PR DESCRIPTION
## Summary
PR 3 of the matching rework. Adds a physical-feasibility check: can the driver actually make the pickup by the deadline? Catches "NYC driver for a Tampa pickup in 4h" — a case the current algorithm scores as a "fair" location match but is physically impossible.

## Approach
Travel-time estimate from real geocoded miles (the PR 2 Radar payload), compared against time-until-pickup:

- Deadhead miles via Radar coords (driver location → load origin).
- Travel hours = `miles / 50 mph` (highway average — rough, but fine for the obvious-fail case).
- HOS sleep buffer: +10 hours when the deadhead exceeds 600 miles (one reset).
- Deadline: end of `pickupDate` local time.
- Three tiers:
  - **Feasible** — comfortable schedule.
  - **Tight** — feasible but using > 70% of available time.
  - **Infeasible** — physically can't make it.

Skipped entirely (no signal, no penalty) when we lack driver coords, load coords, or a parseable pickupDate. This is a *sanity check*, not a hard policy.

## Changes

### `src/lib/matching.ts`
- New `PickupFeasibility` type on `MatchScoreBreakdown` (`feasible`, `tightSchedule`, `estimatedMiles`, `estimatedTravelHours`, `hoursUntilPickup`, `reason`).
- `computePickupFeasibility()` returns the tier given coords + pickupDate.
- `calculateMatchScore` / `calculateMatchScoreAsync` feed feasibility into `buildBreakdown`.
- `findMatchingDrivers` / `findMatchingDriversAsync` / `findMatchingLoads` sort infeasible drivers/loads to the bottom of the list. Within each tier (feasible vs infeasible), the existing score-desc ordering is preserved. `isBestMatch` never applies to an infeasible candidate.

### `src/app/dashboard/matches/page.tsx`
- Red banner on the match card: **"Cannot make pickup in time — ~Xh drive vs Yh until pickup"** when infeasible. Card opacity drops to 70% so the OO instantly distinguishes them.
- Amber banner: **"Tight pickup window"** when feasible but cutting it close.
- Card layout otherwise unchanged.

## Setup Required
- None (uses the Radar coordinates already cached by PR 2).

## Not in this PR (deferred — likely PR 4 / 5 if you want them)
- Real **11/14/10 HOS** state tracking (requires driver duty-status feed).
- **Pickup time-of-day windows** — today we use end-of-day as the deadline; in reality some loads have specific pickup appointments.
- **Telematics-aware truck position** — we use the driver's static `location` field. If we ever wire ELD data, real-time truck position should refine this further.

## Test Plan
- [ ] On QA: post a load with `pickupDate` = today (or tomorrow) and `origin = "Tampa, FL"`. A driver located in `"New York, NY"` (~1100 mi) should now show with a red **"Cannot make pickup in time"** banner and sort to the bottom of Ranked Matches.
- [ ] Same setup but pickup 5 days out: the New York driver should now show with **green/no banner** (feasible) and rank by normal score.
- [ ] Pickup 36 hours out for a 1000-mile deadhead: should show **amber "Tight pickup window"** banner (>70% of available time).
- [ ] A nearby driver (e.g., Orlando → Tampa ~85 mi for a same-day pickup) → no banner, normal ranking.
- [ ] Inspect a match where the load has no `pickupDate` or the driver has no geocoded location: feasibility section is omitted entirely (no false negatives).
- [ ] Ranked Matches with mixed feasible + infeasible drivers: infeasible ones appear after all feasible ones, regardless of score.
- [ ] Best Match ring + Trophy doesn't accidentally land on an infeasible driver if all feasible ones happen to score lower.

> Targets `qa` per the CLAUDE.md default. Merging after this is opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_