### PR TITLE
fix(error): show error.message + digest in production error boundary

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -40,11 +40,27 @@ export default function Error({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {process.env.NODE_ENV === 'development' && (
-            <div className="bg-muted p-4 rounded-md text-left text-xs text-muted-foreground overflow-auto max-h-32">
-              <p className="font-mono">{error.message}</p>
-            </div>
-          )}
+          {/* Always show the error message + digest so QA / users can report
+              concrete details, not just "it broke." The original code hid this
+              behind NODE_ENV === 'development' which made every production
+              failure impossible to attribute. The digest is also a Next.js-
+              generated server-side error id that pairs to the server log
+              entry, so even when the message is generic we can correlate. */}
+          <div className="bg-muted p-4 rounded-md text-left text-xs text-muted-foreground overflow-auto max-h-48 space-y-2">
+            {error.message && (
+              <p className="font-mono break-words whitespace-pre-wrap">
+                <span className="font-semibold not-italic">Error:</span> {error.message}
+              </p>
+            )}
+            {error.digest && (
+              <p className="font-mono break-all">
+                <span className="font-semibold not-italic">Digest:</span> {error.digest}
+              </p>
+            )}
+            {!error.message && !error.digest && (
+              <p className="italic">No additional details available.</p>
+            )}
+          </div>
         </CardContent>
         <CardFooter className="flex justify-center gap-4">
           <Button onClick={() => reset()}>Try Again</Button>


### PR DESCRIPTION
## Summary
The route-level error boundary at `src/app/error.tsx` hid `error.message` behind `NODE_ENV === 'development'`. Any client-side render exception on QA / prod surfaced as a generic "Oops, Something Went Wrong" card with no actionable information. We just hit this on the matches page click flow.

Always render the message + Next.js `error.digest` now. The digest is the same id that's emitted to server logs, so even if the user-visible message is opaque we can correlate to a specific server-side trace.

## Changes
- **`src/app/error.tsx`** — removed the `NODE_ENV === 'development'` gate on the error-detail block. Always shows `Error: <message>` and `Digest: <digest>` when either is present, in a small mono block below the generic copy. Layout otherwise identical.

## Setup Required
- None.

## Test Plan
- [ ] Force any client-side exception (e.g., throw from a useEffect on a temporary page) and confirm the error card now displays both the message and the digest.
- [ ] No layout regression on the normal Oops card (still centered, same Try Again / Homepage buttons).

> Tiny standalone fix; targets `qa` per the default. Merge so the next time you re-test the matches click flow, the actual error stack is visible on screen.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_