### PR TITLE
fix(matches): guard load.weight.toLocaleString() crash in match request modals

### DIFF
--- a/src/components/driver-match-request-modal.tsx
+++ b/src/components/driver-match-request-modal.tsx
@@ -260,7 +260,10 @@ export function DriverMatchRequestModal({
               {load.origin} → {load.destination}
             </p>
             <p className="text-sm text-muted-foreground">
-              {load.cargo} • {load.weight.toLocaleString()} lbs
+              {load.cargo || load.loadType || 'Load'}
+              {load.weight != null && (
+                <> • {load.weight.toLocaleString()} lbs</>
+              )}
             </p>
             {loadOwnerName && (
               <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1">

--- a/src/components/match-request-modal.tsx
+++ b/src/components/match-request-modal.tsx
@@ -273,7 +273,10 @@ export function MatchRequestModal({
               {load.origin} → {load.destination}
             </p>
             <p className="text-sm text-muted-foreground">
-              {load.cargo} • {load.weight.toLocaleString()} lbs
+              {load.cargo || load.loadType || 'Load'}
+              {load.weight != null && (
+                <> • {load.weight.toLocaleString()} lbs</>
+              )}
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
Fixes the crash you just hit when clicking into a matched driver from `/dashboard/matches`:

```
TypeError: Cannot read properties of undefined (reading 'toLocaleString')
```

## Root cause
The current `/api/loads` Zod schema (`src/app/api/loads/route.ts`) requires `origin / destination / loadType / driverCompensation / pickupDate / cdlClassRequired` but does **not** require `weight` (and legacy `price` is also absent on new loads). So loads created today land in Firestore without those fields. Any UI that called `.toLocaleString()` on them blew up.

The matches page itself (`src/app/dashboard/matches/page.tsx`) had already been guarded with optional chaining + truthy checks. **The two request-driver modals had not** — and they're the ones the click flow opens.

## Changes
- **`src/components/match-request-modal.tsx`** (OO requests a driver for a load) — line 276 area. Was: `{load.cargo} • {load.weight.toLocaleString()} lbs`. Now: render `cargo || loadType || 'Load'`, then conditionally append `• <weight> lbs` only when `weight != null`.
- **`src/components/driver-match-request-modal.tsx`** (mirror flow on the driver side) — same defensive change at line 263.

The fix is purely render-side defensive coding — no schema change, no data migration.

## Setup Required
- None.

## Not in this PR (deserves its own cleanup later)
- A real **schema-level decision**: either make `weight` required in `/api/loads` POST + the new-load form, or fully accept its absence and audit every other surface (load detail page, edit modal, email templates, etc.) for the same crash pattern. This is the right next step but it's bigger than a hotfix.

## Test Plan
- [ ] On QA: select a load that has no `weight` field (e.g., the Naples → Detroit one). Click into a driver match → **Request Driver** modal opens cleanly with header "Load Type • " or "Load" and no `lbs` segment. No error boundary.
- [ ] Same flow on a load that DOES have `weight` set: modal still shows `<cargo> • 4,500 lbs` correctly.
- [ ] Driver-side request modal opens cleanly for both load shapes.
- [ ] No regression elsewhere on the matches page.

> Targets `qa` per the CLAUDE.md default. Merging right after this opens.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_