### PR TITLE
fix(auth): consolidate owner registration into atomic POST /api/register

### DIFF
--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { handleApiError, handleApiSuccess } from '@/lib/api-error-handler';
+import { withCors } from '@/lib/api-cors';
+import { rateLimiters, getIdentifier, formatTimeRemaining } from '@/lib/rate-limit';
+import { passwordSchema } from '@/lib/password-validation';
+import { buildAttestationEntry } from '@/lib/attestations';
+import { sendOwnerRegistrationEmail } from '@/lib/email';
+import { NextResponse } from 'next/server';
+
+const LOG_PREFIX = '[register]';
+
+const bodySchema = z.object({
+  email: z.string().email('A valid email is required'),
+  password: z.string().min(1, 'Password is required'),
+  companyName: z.string().min(1, 'Company name is required'),
+});
+
+/**
+ * Consolidated owner registration.
+ *
+ * Replaces the previous client-side flow (createUserWithEmailAndPassword +
+ * two client setDoc calls + a separate /api/auth/session POST), which had a
+ * class of bugs:
+ *   - Non-atomic: the Auth user could be created while the Firestore docs
+ *     failed, leaving a half-provisioned account.
+ *   - Client/server desync: a stale fb-id-token cookie from a prior account
+ *     could survive a fresh signup, so the server (cookie) and the client
+ *     (Firebase Auth) ended up pointing at different uids — the "two users
+ *     at once" bug seen on the loads / My-Assets mismatch.
+ *
+ * This route does everything server-side and atomically:
+ *   1. Rate limit by IP.
+ *   2. Validate input (incl. password policy).
+ *   3. Admin SDK createUser — fails fast on email-already-exists.
+ *   4. Write owner_operators/{uid} + users/{uid} in the same request.
+ *   5. Mint a custom token for the client to sign in with cleanly.
+ *   6. Fire the welcome email (best-effort, non-blocking).
+ *
+ * The client then does signInWithCustomToken() (which cleanly replaces any
+ * prior client auth state) and the usual ID-token → session-cookie exchange.
+ * The session cookie itself still can't be minted here — createSessionCookie
+ * needs an ID token, which only exists after the client signs in — but the
+ * user + docs are now guaranteed consistent before the client touches auth.
+ */
+async function handlePost(req: NextRequest) {
+  try {
+    // 1. Rate limit (IP-based; runs before any account work). Uses the
+    // auth bucket (20 / 15m) rather than the stricter registration bucket
+    // (3 / hour) so QA testing isn't constantly locked out.
+    const identifier = getIdentifier(req);
+    const { success, reset } = await rateLimiters.auth.limit(identifier);
+    if (!success) {
+      return NextResponse.json(
+        {
+          error: 'Too many signup attempts',
+          message: `Please try again in ${formatTimeRemaining(reset)}`,
+        },
+        { status: 429 },
+      );
+    }
+
+    // 2. Validate input.
+    const body = await req.json();
+    const parsed = bodySchema.safeParse(body);
+    if (!parsed.success) {
+      throw new Error(
+        Object.values(parsed.error.flatten().fieldErrors).flat().join(', ') || 'Invalid request body',
+      );
+    }
+    const { email, password, companyName } = parsed.data;
+
+    const pw = passwordSchema.safeParse(password);
+    if (!pw.success) {
+      throw new Error(pw.error.errors[0]?.message || 'Password does not meet requirements');
+    }
+
+    const { auth, db } = await getFirebaseAdmin();
+
+    // 3. Create the Firebase Auth user. Fails fast (before any Firestore
+    // writes) if the email is taken.
+    let uid: string;
+    try {
+      const userRecord = await auth.createUser({
+        email,
+        password,
+        emailVerified: false,
+      });
+      uid = userRecord.uid;
+      console.log(`${LOG_PREFIX} Created auth user ${uid} for ${email}`);
+    } catch (err: any) {
+      const code = err?.errorInfo?.code || err?.code || '';
+      if (code === 'auth/email-already-exists') {
+        return NextResponse.json(
+          { error: 'This email is already in use. Try logging in instead.' },
+          { status: 409 },
+        );
+      }
+      if (code === 'auth/invalid-password') {
+        return NextResponse.json(
+          { error: 'Password does not meet security requirements.' },
+          { status: 400 },
+        );
+      }
+      throw err;
+    }
+
+    const createdAt = new Date().toISOString();
+
+    // 4. Write the owner_operators + users docs. If either throws, clean up
+    // the auth user so we never leave a half-provisioned account behind.
+    try {
+      await db
+        .collection('owner_operators')
+        .doc(uid)
+        .set({
+          id: uid,
+          companyName,
+          legalName: companyName,
+          contactEmail: email,
+          subscriptionStatus: 'inactive',
+          createdAt,
+          onboardingStatus: {
+            profileComplete: false,
+            fmcsaDesignated: false,
+            completedAt: null,
+          },
+          // DEV-154 staged-attestation model — signup surface.
+          attestations: [
+            buildAttestationEntry('signupAuthorized', uid),
+            buildAttestationEntry('signupEsignConsent', uid),
+            buildAttestationEntry('signupTermsOfService', uid),
+          ],
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+
+      await db.collection('users').doc(uid).set({
+        role: 'owner_operator',
+        email,
+        createdAt,
+      });
+    } catch (err) {
+      console.error(`${LOG_PREFIX} Firestore write failed for ${uid} — rolling back auth user`, err);
+      try {
+        await auth.deleteUser(uid);
+      } catch (cleanupErr) {
+        console.error(`${LOG_PREFIX} Failed to roll back auth user ${uid}`, cleanupErr);
+      }
+      throw new Error('Failed to provision account. Please try again.');
+    }
+
+    // 5. Mint a custom token for the client to sign in with. signInWith-
+    // CustomToken on the client cleanly replaces any stale auth state.
+    const customToken = await auth.createCustomToken(uid);
+
+    // 6. Welcome email — best-effort, never blocks the response.
+    sendOwnerRegistrationEmail(email, companyName).catch((err) =>
+      console.error(`${LOG_PREFIX} welcome email failed for ${email}`, err),
+    );
+
+    return handleApiSuccess({
+      success: true,
+      uid,
+      email,
+      customToken,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`${LOG_PREFIX} Error:`, msg, error);
+    return handleApiError('server', error instanceof Error ? error : new Error(msg), {
+      endpoint: 'POST /api/register',
+    });
+  }
+}
+
+export const POST = withCors(handlePost);

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -16,14 +16,13 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Logo } from "@/components/logo";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { useUser, useAuth, useFirestore } from "@/firebase";
+import { useUser, useAuth } from "@/firebase";
 import { Suspense, useState, FormEvent } from "react";
-import { createUserWithEmailAndPassword } from "firebase/auth";
-import { doc, setDoc } from "firebase/firestore";
+import { signInWithCustomToken } from "firebase/auth";
 import { Loader2, LogOut, LayoutDashboard, Building2, Truck, Check, X } from "lucide-react";
 import { showSuccess, showError } from "@/lib/toast-utils";
 import { passwordSchema } from "@/lib/password-validation";
-import { ATTESTATIONS, buildAttestationEntry } from "@/lib/attestations";
+import { ATTESTATIONS } from "@/lib/attestations";
 
 function RegisterContent() {
   const searchParams = useSearchParams();
@@ -34,7 +33,6 @@ function RegisterContent() {
   const router = useRouter();
   const { user, isUserLoading } = useUser();
   const auth = useAuth();
-  const db = useFirestore();
 
   const handleSignOut = async () => {
     setSigningOut(true);
@@ -77,94 +75,85 @@ function RegisterContent() {
     }
 
     try {
-      const userCredential = await createUserWithEmailAndPassword(auth, email, password);
-      const newUser = userCredential.user;
-      
-      if (db && newUser) {
-        await setDoc(doc(db, "owner_operators", newUser.uid), {
-          id: newUser.uid,
-          companyName: companyName,
-          legalName: companyName,
-          contactEmail: newUser.email,
-          subscriptionStatus: 'inactive',
-          createdAt: new Date().toISOString(),
-          onboardingStatus: {
-            profileComplete: false,
-            fmcsaDesignated: false,
-            completedAt: null,
-          },
-          // DEV-154 staged-attestation model. signupAuthorized is the explicit
-          // checkbox; the other two are click-acknowledged via the text below
-          // the Create Company Account button (E-Sign, Terms of Service).
-          // User Agreement consent is captured separately inside the auth-
-          // ed app per DEV-156 follow-up, not at signup. Additional
-          // attestations are captured later at moments of risk (profile /
-          // driver-add / match-confirm).
-          attestations: [
-            buildAttestationEntry('signupAuthorized', newUser.uid),
-            buildAttestationEntry('signupEsignConsent', newUser.uid),
-            buildAttestationEntry('signupTermsOfService', newUser.uid),
-          ],
-        });
-        
-        await setDoc(doc(db, "users", newUser.uid), {
-          role: 'owner_operator',
-          email: newUser.email,
-          createdAt: new Date().toISOString(),
-        });
-
-        const token = await newUser.getIdToken();
-
-        // POST session cookie and WAIT for it to complete before redirecting.
-        // This sets the fb-id-token cookie that the server action behind the
-        // CompanyProfileForm relies on.
-        const sessionResponse = await fetch('/api/auth/session', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token }),
-        });
-
-        // Send welcome email fire-and-forget — do NOT await
-        fetch('/api/send-welcome-email', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: newUser.email, companyName }),
-        }).catch(err => console.error('Failed to send welcome email:', err));
-
-        if (!sessionResponse.ok) {
-          // The Firebase Auth user + Firestore docs were written successfully,
-          // we just couldn't establish a session cookie (rate limit, transient
-          // infra, etc.). Don't show a generic red error — the account exists.
-          // Bounce the user to the login page so they can sign in cleanly.
-          console.warn('[register] Session POST failed after successful account creation', sessionResponse.status);
-          showSuccess('Account created. Please sign in to continue.');
-          router.push(`/login?email=${encodeURIComponent(newUser.email || '')}&message=Account created. Please log in to continue.`);
-          return;
-        }
-
-        showSuccess('Account created successfully!');
-
-        // Hard navigation (window.location.href) instead of router.push so the
-        // next request carries the freshly-Set-Cookie'd fb-id-token in its
-        // request headers — soft client-side navigation can race the browser
-        // cookie write and result in the server action seeing no cookie.
-        window.location.href = '/create-profile';
-        return;
-
-      } else {
-        throw new Error("Database service is not available.");
+      // Clear any stale session before creating a new account. Without this,
+      // a leftover fb-id-token cookie + client Auth state from a *previous*
+      // account survives the new signup, and the server (cookie) and client
+      // (Firebase Auth) end up pointing at different uids — the "two users
+      // at once" bug. Best-effort: failures here don't block the new signup.
+      try {
+        await auth.signOut();
+        await fetch('/api/auth/session', { method: 'DELETE' });
+      } catch (clearErr) {
+        console.warn('[register] failed to clear prior session (continuing)', clearErr);
       }
 
+      // Create the account server-side and atomically — Auth user +
+      // owner_operators doc + users doc all in one request. Returns a
+      // custom token for the client to sign in with.
+      const registerRes = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, companyName }),
+      });
+      const registerData = await registerRes.json().catch(() => ({}));
+
+      if (!registerRes.ok) {
+        const message =
+          registerData?.error ||
+          registerData?.message ||
+          'An error occurred during sign up.';
+        setError(message);
+        showError(message);
+        setLoading(false);
+        return;
+      }
+
+      const customToken: string | undefined = registerData?.data?.customToken ?? registerData?.customToken;
+      if (!customToken) {
+        // Account exists but we can't sign the user in client-side — send
+        // them to login rather than showing a scary error.
+        showSuccess('Account created. Please sign in to continue.');
+        router.push(`/login?email=${encodeURIComponent(email)}&message=Account created. Please log in to continue.`);
+        return;
+      }
+
+      // Sign in client-side with the custom token. This cleanly establishes
+      // the client Firebase Auth state for the new user (no stale carryover).
+      const userCredential = await signInWithCustomToken(auth, customToken);
+      const idToken = await userCredential.user.getIdToken();
+
+      // Exchange the ID token for the fb-id-token session cookie.
+      const sessionResponse = await fetch('/api/auth/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: idToken }),
+      });
+
+      if (!sessionResponse.ok) {
+        // Account + docs exist; only the cookie didn't land (rate limit /
+        // transient infra). Don't show a red error — route to login.
+        console.warn('[register] Session POST failed after successful account creation', sessionResponse.status);
+        showSuccess('Account created. Please sign in to continue.');
+        router.push(`/login?email=${encodeURIComponent(email)}&message=Account created. Please log in to continue.`);
+        return;
+      }
+
+      showSuccess('Account created successfully!');
+
+      // Hard navigation so the next request carries the freshly-Set-Cookie'd
+      // fb-id-token — soft client-side navigation can race the cookie write.
+      window.location.href = '/create-profile';
+      return;
     } catch (e: unknown) {
       console.error('Sign-up error:', e);
       let errorMessage = 'An error occurred during sign up.';
       const firebaseError = e as { code?: string };
-      if (firebaseError.code === 'auth/email-already-in-use') {
-        errorMessage = 'This email is already in use. Try logging in instead.';
-      } else if (firebaseError.code === 'auth/weak-password') {
-        errorMessage = 'Password does not meet security requirements.';
-      } else if (firebaseError.code === 'auth/invalid-email') {
-        errorMessage = 'Please enter a valid email address.';
+      if (firebaseError.code === 'auth/invalid-custom-token' || firebaseError.code === 'auth/custom-token-mismatch') {
+        // The server-side account was created but client sign-in failed.
+        // The user can still log in normally.
+        showSuccess('Account created. Please sign in to continue.');
+        router.push(`/login?message=Account created. Please log in to continue.`);
+        return;
       }
       setError(errorMessage);
       showError(errorMessage);


### PR DESCRIPTION
## Summary
The real fix for the signup session bug (#1/#2/#3) that survived #156's partial patch — including the "two users at once" symptom where `/dashboard/loads` and Find Match's My Assets showed different load sets.

## The bug
The old signup flow ran entirely client-side: `createUserWithEmailAndPassword` → two client `setDoc` calls → a separate `POST /api/auth/session`. Two failure classes:

1. **Non-atomic** — the Auth user could be created while a Firestore write failed, leaving a half-provisioned account.
2. **Client/server uid desync** — a stale `fb-id-token` cookie + client Auth state from a *previous* account survived a fresh signup. The server (cookie uid) and client (Firebase Auth uid) ended up on different users. That's why `/dashboard/loads` (server-rendered, cookie uid) and Find Match's My Assets (client-rendered, Auth uid) showed completely different loads.

## The fix

### New: `src/app/api/register/route.ts`
- IP rate limit (auth bucket, 20/15m — lenient enough for QA testing).
- Zod + password-policy validation.
- Admin SDK `createUser` — fails fast on email-already-exists (409) **before** any Firestore writes.
- Writes `owner_operators/{uid}` (with the three signup attestations) and `users/{uid}` in the same request. If either write throws, the Auth user is rolled back via `deleteUser` — no half-provisioned accounts.
- Mints a custom token, returns it.
- Fires the welcome email server-side, best-effort.

### `src/app/register/page.tsx`
`handleRegister` now:
1. **Clears any stale session up front** (`auth.signOut()` + `DELETE /api/auth/session`) — a prior account can no longer bleed into the new one.
2. `POST /api/register` — atomic server-side creation.
3. `signInWithCustomToken` — cleanly (re)establishes client Auth state for the *new* uid.
4. Exchanges the ID token for the `fb-id-token` cookie via `/api/auth/session`.
5. Hard-navigates to `/create-profile`.

Graceful degradation preserved: if custom-token sign-in OR the session-cookie POST fails, the account still exists → "Account created. Please sign in." → `/login`, not a red error banner.

## Why the session cookie still isn't minted inside `/api/register`
`createSessionCookie` requires an **ID token**, which only exists after the client signs in. That round-trip through the client is fundamental to Firebase Auth — it can't be collapsed away. But the meaningful wins land regardless: the user + docs are now atomic, and the client *always* signs in fresh via the custom token, which is what actually kills the desync.

## Setup Required
- None. (`/api/register` uses the existing `getFirebaseAdmin` singleton + `rateLimiters.auth`.)

## Test Plan
- [ ] **Happy path:** fresh incognito → `/register` → submit → lands on `/create-profile`, no red banner. Firestore has `owner_operators/{uid}` (with 3 attestations) + `users/{uid}`, both with the same uid as the `fb-id-token` cookie.
- [ ] **The desync repro:** sign up account A, then *without clearing cookies* sign up account B in the same browser. Confirm `/dashboard/loads` and `/dashboard/matches` My Assets now show the **same** (account B) data — the stale-session clear at the top of `handleRegister` fixes this.
- [ ] **Email already in use:** sign up with an existing email → inline 409 error "This email is already in use. Try logging in instead.", no account created, no error boundary.
- [ ] **Atomic rollback:** (hard to simulate without breaking Firestore) — if a Firestore write fails, the Auth user should be deleted; verify no orphan Auth users accumulate.
- [ ] **Weak password:** server rejects with the password-policy message; no account created.
- [ ] **Session-cookie failure path:** block `/api/auth/session` in DevTools after `/api/register` succeeds → "Account created. Please sign in." toast + redirect to `/login` (account still exists, login works).
- [ ] Existing login flow + driver-invite signup flow are untouched and still work.

> Targets `qa` per the CLAUDE.md default. Merging after this opens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_