### PR TITLE
fix(register): owner signup 500 — undefined attestation field

### DIFF
--- a/src/lib/attestations.ts
+++ b/src/lib/attestations.ts
@@ -223,16 +223,19 @@ export function buildAttestationEntry(
   } = {},
 ): AttestationEntry {
   const def = ATTESTATIONS[type];
-  return {
+  // Only include optional fields when defined — Firestore rejects `undefined`
+  // values, and server callers frequently omit ip / userAgent / context.
+  const entry: AttestationEntry = {
     type,
     version: def.v,
     text: def.text,
     acceptedAt: new Date().toISOString(),
     acceptedBy,
-    ip: opts.ip,
-    userAgent: opts.userAgent,
-    context: opts.context,
   };
+  if (opts.ip !== undefined) entry.ip = opts.ip;
+  if (opts.userAgent !== undefined) entry.userAgent = opts.userAgent;
+  if (opts.context !== undefined) entry.context = opts.context;
+  return entry;
 }
 
 /**

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,53 +1,56 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 
-// Initialize Redis client
-const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-});
+// Whether Upstash Redis is configured. When it isn't (local dev, E2E against
+// the Firebase emulators), there's no Redis to talk to — constructing the
+// client with an empty URL makes every `.limit()` call throw
+// "Failed to parse URL from /pipeline" and 500s the route. In that case we
+// fall back to a no-op limiter that always allows.
+const upstashConfigured = Boolean(
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN,
+);
+
+type Limiter = Pick<Ratelimit, 'limit'>;
+
+const noopLimiter: Limiter = {
+  limit: async () => ({
+    success: true,
+    limit: 0,
+    remaining: 0,
+    reset: Date.now(),
+    pending: Promise.resolve(),
+  }),
+};
+
+function makeLimiter(requests: number, window: Parameters<typeof Ratelimit.slidingWindow>[1], prefix: string): Limiter {
+  if (!upstashConfigured) return noopLimiter;
+  return new Ratelimit({
+    redis: new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL!,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+    }),
+    limiter: Ratelimit.slidingWindow(requests, window),
+    analytics: true,
+    prefix,
+  });
+}
 
 // Define rate limiters for different use cases
 export const rateLimiters = {
   // Login/Auth: 20 attempts per 15 minutes
-  auth: new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(20, '15 m'),
-    analytics: true,
-    prefix: 'ratelimit:auth',
-  }),
+  auth: makeLimiter(20, '15 m', 'ratelimit:auth'),
 
   // Token refresh: 30 per 15 minutes (higher limit for session refreshes)
-  tokenRefresh: new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(30, '15 m'),
-    analytics: true,
-    prefix: 'ratelimit:tokenRefresh',
-  }),
+  tokenRefresh: makeLimiter(30, '15 m', 'ratelimit:tokenRefresh'),
 
   // Driver invitations: 10 per hour
-  invitations: new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(10, '1 h'),
-    analytics: true,
-    prefix: 'ratelimit:invitations',
-  }),
+  invitations: makeLimiter(10, '1 h', 'ratelimit:invitations'),
 
   // Load creation: 20 per hour
-  loads: new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(20, '1 h'),
-    analytics: true,
-    prefix: 'ratelimit:loads',
-  }),
+  loads: makeLimiter(20, '1 h', 'ratelimit:loads'),
 
   // Driver registration: 3 per hour per IP (prevent abuse)
-  registration: new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(3, '1 h'),
-    analytics: true,
-    prefix: 'ratelimit:registration',
-  }),
+  registration: makeLimiter(3, '1 h', 'ratelimit:registration'),
 };
 
 // Helper function to get client identifier (IP or user ID)


### PR DESCRIPTION
## Summary
- Owner signup is **currently broken on QA** — `POST /api/register` returns 500 ("An error occurred. Please try again later.") and shows the red error banner.
- Root cause: `buildAttestationEntry` writes an `ip` field that's `undefined` (the register route never passes one), and Firestore rejects `undefined` values, failing the `owner_operators` write.
- Also hardens `rate-limit.ts` so it doesn't crash when Upstash isn't configured (local dev / E2E).

## Changes
- `src/lib/attestations.ts` — `buildAttestationEntry` now only includes `ip` / `userAgent` / `context` when they're defined, instead of always setting them (Firestore rejects `undefined`).
- `src/lib/rate-limit.ts` — falls back to a no-op limiter that always allows when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are absent. Previously the Upstash client was built with an empty URL and every `.limit()` call threw `Failed to parse URL from /pipeline`. No behavior change on QA/prod, which have Upstash configured.

## Setup Required
- None.

## Test Plan
- [x] Verified end-to-end against the local Firebase emulators: `POST /api/register` → 200 `{success, uid, email}`, client SDK sign-in → ok, `POST /api/auth/session` → 200 + `fb-id-token` cookie set.
- [ ] On QA after merge: register a brand-new company account → no red banner → lands on `/create-profile`.
- [ ] On QA: existing login flow still works (rate limiter unaffected — Upstash configured).

https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_