### PR TITLE
fix(attestations): omit undefined userAgent in append-attestations route

### DIFF
--- a/src/app/api/append-attestations/route.ts
+++ b/src/app/api/append-attestations/route.ts
@@ -100,7 +100,8 @@ async function handlePost(req: NextRequest) {
         acceptedAt,
         acceptedBy: owner.uid,
         ip: ipAddress,
-        userAgent,
+        // Firestore rejects undefined values — only include userAgent when present.
+        ...(userAgent !== undefined ? { userAgent } : {}),
         ...(hasDriverTypes
           ? { context: { driverId, ...(deviceInfo ? { deviceInfo } : {}) } }
           : deviceInfo


### PR DESCRIPTION
## Summary
- The attestation-recapture route (`/api/append-attestations`) built entries inline and always wrote a `userAgent` field. When the `user-agent` request header is missing, `userAgent` is `undefined`, and Firestore rejects `undefined` values — so the `arrayUnion` write fails.
- Same class of bug as the register-route 500 fixed in #167; this hardens the recapture surface (`AttestationRecaptureSheet`) against it.

## Changes
- `src/app/api/append-attestations/route.ts` — only include `userAgent` in the attestation entry when it's defined, matching `buildAttestationEntry`'s conditional-field pattern.

## Setup Required
- None.

## Test Plan
- [ ] On QA: trigger an attestation recapture (profile or driver_add surface) from a normal browser → succeeds (browsers always send `user-agent`, so this is the happy path and should be unaffected).
- [ ] Latent edge case (hard to reproduce via browser): a request with no `user-agent` header no longer 500s the recapture write.

https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_