### PR TITLE
fix(profile): HQ address round-trips through Street/City/State/ZIP fields

### DIFF
--- a/src/components/company-profile-form.tsx
+++ b/src/components/company-profile-form.tsx
@@ -89,11 +89,13 @@ export function CompanyProfileForm() {
           // single comma-separated string. Try to split it into Street /
           // City / State / Zip so the form's individual fields populate
           // instead of dumping the entire address into the Street input.
-          // Expected shape: "Street, City, ST 12345" (FMCSA-style).
+          // Accepts both FMCSA-style "Street, City, ST 12345" and the
+          // form's own ", "-joined "Street, City, ST, 12345" (the latter
+          // was produced by the onSubmit join and the parser used to miss
+          // it, round-tripping the address into the Street field).
           if (!data.hqStreet && !data.hqCity && !data.hqState && !data.hqZip && data.hqAddress) {
             const legacy = String(data.hqAddress).trim();
-            // Match trailing "ST 12345" (or 12345-1234 ZIP+4)
-            const cszMatch = legacy.match(/^(.*),\s*([A-Za-z][A-Za-z\s.'-]+),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)\s*$/);
+            const cszMatch = legacy.match(/^(.*),\s*([A-Za-z][A-Za-z\s.'-]+),\s*([A-Za-z]{2})[\s,]+(\d{5}(?:-\d{4})?)\s*$/);
             if (cszMatch) {
               const [, streetPart, cityPart, statePart, zipPart] = cszMatch;
               form.setValue('hqStreet', streetPart.trim());
@@ -211,7 +213,13 @@ export function CompanyProfileForm() {
       formData.append('hqCity', values.hqCity || '');
       formData.append('hqState', values.hqState || '');
       formData.append('hqZip', values.hqZip || '');
-      const hqAddress = [values.hqStreet, values.hqCity, values.hqState, values.hqZip].filter(Boolean).join(', ');
+      // Canonical FMCSA-style join: "Street, City, ST ZIP" (space, not
+      // comma, before the ZIP). Keeps the combined hqAddress field
+      // round-trippable by the legacy parser above.
+      const cityStateZip = [values.hqCity, [values.hqState, values.hqZip].filter(Boolean).join(' ')]
+        .filter(Boolean)
+        .join(', ');
+      const hqAddress = [values.hqStreet, cityStateZip].filter(Boolean).join(', ');
       formData.append('hqAddress', hqAddress);
       formData.append('operatingStates', JSON.stringify(values.operatingStates || []));
       formData.append('coiData', JSON.stringify(coiData));


### PR DESCRIPTION
## Summary
- On the Company Information section of the profile editor, a saved HQ address loads as a single combined string into the "HQ Address" (street) field while City / State / ZIP stay empty. Reproduced on QA — the screenshot shows "12375 KERRAN STREET, POWAY, CA, 92064" in the Street input, with the other three fields blank.
- Two interacting bugs cause this. Fixing both makes the address round-trip through the four split fields cleanly.

## Root cause
1. **Submit join** (`onSubmit`) joined parts with `', '` everywhere — *including* between state and ZIP — producing `"Street, City, ST, ZIP"` (comma between state and ZIP).
2. **Load-time legacy parser regex** expected the FMCSA-style `"Street, City, ST 12345"` (space, not comma, before the ZIP), so the format the form itself had just saved failed to match. It fell through to "could not parse confidently" and dumped the entire string into the Street field.

Live FMCSA re-verification works (`phyState` / `phyZipcode` come back as separate fields), which is why clicking **Re-verify** would temporarily fix it — but reload re-broke it.

## Changes
- `src/components/company-profile-form.tsx`
  - **Submit join** now produces the canonical `"Street, City, ST ZIP"` (space before ZIP) so the combined `hqAddress` field stays round-trippable.
  - **Parser regex** accepts both whitespace and comma between state and ZIP (`[\s,]+`), so existing accounts that were saved in the old buggy format also split correctly on next load — no migration script needed.

## Setup Required
- None.

## Test Plan
- [ ] On QA: open an account that already exhibits the bug (e.g. the one in the screenshot). The Street / City / State / ZIP fields should now all be populated correctly on first load — no Re-verify needed.
- [ ] On QA: edit and save the profile, reload, confirm the fields stay split correctly.
- [ ] On QA: a fresh DOT lookup (Re-verify) still populates the split fields correctly (unchanged path).

https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_