### PR TITLE
feat(matches): gate the match marketplace on profile attestations (DEV-154 Layer 2)

### DIFF
--- a/src/app/dashboard/matches/page.tsx
+++ b/src/app/dashboard/matches/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { Driver, Load } from "@/lib/data";
 import { Badge } from "@/components/ui/badge";
@@ -25,6 +27,7 @@ import {
   Briefcase,
   Award,
   X,
+  Loader2,
 } from "lucide-react";
 import { useUser, useFirestore } from "@/firebase";
 import { collection, query, where, collectionGroup, doc, getDoc, onSnapshot } from "firebase/firestore";
@@ -50,6 +53,7 @@ import {
 } from "@/components/ui/sheet";
 import { ComplianceScorecard, ScoringFormulaExplainer } from "@/components/compliance-scorecard";
 import { getComplianceStatus, type ComplianceStatus } from "@/lib/compliance";
+import { hasCurrent, type AttestationEntry, type AttestationType } from "@/lib/attestations";
 
 type DriverWithOwner = Driver & { ownerId: string };
 type LoadWithOwner = Load & { ownerId: string };
@@ -84,6 +88,35 @@ export default function MatchesPage() {
 
   const { user } = useUser();
   const firestore = useFirestore();
+
+  // Gate: the match marketplace (and the match-request modals reachable only
+  // from it) require the owner's profile-level compliance attestations to be
+  // current — the DEV-154 "soft compliance layer" trigger for viewing the
+  // marketplace and requesting matches. Mirrors the load-post gate.
+  // States: 'checking' until the owner doc fetch resolves, then 'blocked' if
+  // profileInsurance or profileAuthority is missing, otherwise 'ok'.
+  const [gateState, setGateState] = useState<'checking' | 'blocked' | 'ok'>('checking');
+  const [missingProfileAttestations, setMissingProfileAttestations] = useState<AttestationType[]>([]);
+
+  useEffect(() => {
+    async function checkProfileAttestations() {
+      if (!user || !firestore) return;
+      try {
+        const snap = await getDoc(doc(firestore, 'owner_operators', user.uid));
+        const data = snap.exists() ? (snap.data() as { attestations?: AttestationEntry[] }) : {};
+        const required: AttestationType[] = ['profileInsurance', 'profileAuthority'];
+        const missing = required.filter(t => !hasCurrent(data.attestations, t));
+        setMissingProfileAttestations(missing);
+        setGateState(missing.length > 0 ? 'blocked' : 'ok');
+      } catch (err) {
+        console.warn(`${LOG_PREFIX} failed to verify profile attestations`, err);
+        // Fail-open: don't lock the user out on a fetch error. Server-side
+        // gates (Firestore rules / API checks) remain authoritative.
+        setGateState('ok');
+      }
+    }
+    checkProfileAttestations();
+  }, [user, firestore]);
 
   // Subscribe to MY pending loads.
   // "Pending" is the legacy status string; the current /api/loads POST
@@ -307,6 +340,39 @@ export default function MatchesPage() {
       default: return "";
     }
   };
+
+  if (gateState === 'checking') {
+    return (
+      <div className="flex items-center justify-center min-h-[40vh]">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (gateState === 'blocked') {
+    return (
+      <div className="max-w-2xl">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-2xl font-headline">Complete Your Profile First</CardTitle>
+            <CardDescription>Finding matches requires your company-level compliance attestations to be on file.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Missing profile attestation{missingProfileAttestations.length === 1 ? '' : 's'}: <strong>{missingProfileAttestations.join(', ')}</strong>. Capture them on your profile page, then come back to find matches.
+              </AlertDescription>
+            </Alert>
+            <div className="flex gap-2">
+              <Link href="/dashboard/profile"><Button>Go to Profile</Button></Link>
+              <Link href="/dashboard"><Button variant="outline">Cancel</Button></Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Closes the main remaining gap in DEV-154 ("XtraFleet Attestation Architecture") — the **Layer 2 soft-compliance gate**.
- DEV-154 specifies the `profileInsurance` + `profileAuthority` attestation gate should fire on **three** triggers: posting a load, viewing the marketplace, and requesting a match. Only the load-post trigger was wired (in `loads/new`).
- This gates `/dashboard/matches`, covering the other two triggers at once.

## Why one page covers two triggers
Both match-request modals (`MatchRequestModal` load→driver, `DriverMatchRequestModal` driver→load) are only ever opened from `/dashboard/matches`. Gating that page blocks "view marketplace" *and* "request a match" with a single intercept.

## Changes
- `src/app/dashboard/matches/page.tsx` — adds a profile-attestation gate that mirrors the existing `loads/new` gate exactly:
  - Fetches `owner_operators/{uid}`, checks `hasCurrent()` for `profileInsurance` and `profileAuthority`.
  - Renders the "Complete Your Profile First" blocking card (same copy, same "Go to Profile" CTA) when either is missing.
  - `'checking'` spinner while the owner doc loads; **fails open** on a fetch error so a transient failure can't lock users out — server-side Firestore rules / API checks remain authoritative.

## Setup Required
- None.

## Test Plan
- [ ] On QA: a brand-new / profile-incomplete owner visiting `/dashboard/matches` sees the "Complete Your Profile First" card and **cannot** reach the match panels or the request-match buttons.
- [ ] On QA: an owner with both `profileInsurance` and `profileAuthority` captured sees the marketplace normally.
- [ ] "Go to Profile" routes to `/dashboard/profile`; capturing the attestations there and returning unblocks the page.

## Notes
- Logic is a faithful copy of the `loads/new` gate, which is covered by the passing E2E test T3. I could not browser-drive this in the sandbox (Playwright browsers can't be installed here), so the QA test plan above should be run before promotion. A dedicated E2E case for the marketplace gate (mirroring T3) is a cheap follow-up — happy to add it.
- This leaves one smaller DEV-154 item: the 5 `blocking: true` surfaces (match-confirm / tla) that capture but don't enforce. Tracked under DEV-154 itself.

https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_