### PR TITLE
ci: add Next.js build check on PRs to qa/main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build
+
+# Pre-flight: verify the app actually compiles before it can merge into qa.
+# Without this, a broken build only surfaces in the QA App Hosting deploy
+# AFTER merge. This runs the same `next build` the deploy runs, so a broken
+# import / route / server-client violation is caught on the PR instead.
+#
+# Note: next.config.js sets typescript.ignoreBuildErrors and
+# eslint.ignoreDuringBuilds, so this gate verifies compilation, not types
+# or lint — matching exactly what the QA deploy does.
+
+on:
+  pull_request:
+    branches: [qa, main]
+  push:
+    branches: [qa]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Next.js build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Placeholder public Firebase config so any build-time static
+      # generation has values to read. No real credentials needed — the
+      # Admin SDK initializes lazily at request time, not at build time.
+      NEXT_PUBLIC_FIREBASE_PROJECT_ID: xtrafleet-ci
+      NEXT_PUBLIC_FIREBASE_API_KEY: fake-api-key-for-ci
+      NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: localhost
+      NEXT_PUBLIC_FIREBASE_APP_ID: '1:000000000000:web:ci'
+      NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: xtrafleet-ci.appspot.com
+      NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: '000000000000'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds a **build check** to CI — the first gate that verifies the app actually compiles before a PR can merge.
- Today nothing does this: a broken build only surfaces in the QA App Hosting deploy *after* merge (e.g. the #163 lockfile failure). This catches that class of bug on the PR.

## Changes
- New workflow `.github/workflows/build.yml` — runs on PRs to `qa`/`main` (and pushes to `qa`):
  - `npm ci` — same install the QA deploy runs, so it also catches **lockfile drift** (the exact #163 failure).
  - `npm run build` — the same `next build` the deploy runs.
- Verified `npm run build` passes locally before adding the gate.

## What it catches / doesn't
- ✅ Broken imports, missing modules, invalid routes, server/client component violations, lockfile drift.
- ❌ Type errors and lint — `next.config.js` sets `typescript.ignoreBuildErrors` + `eslint.ignoreDuringBuilds`, so the build (and this check) skip them. That's intentional: this gate mirrors *exactly* what the QA deploy does. Making `tsc` a gate is a separate effort (blocked on pre-existing admin-page type errors).

## Setup Required
- None for the workflow itself.
- **Recommended follow-up (repo admin, Settings UI):** add branch protection on `qa` requiring both checks — `Next.js build` and `Playwright + Firebase Emulators` — so PRs can't merge red. Then per-PR auto-merge can land changes into qa automatically once both are green.

## Test Plan
- [ ] This PR's own CI run shows the `Next.js build` check passing.
- [ ] A PR with a deliberately broken import fails the check (sanity check, optional).

https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_