### PR TITLE
test(e2e): add login-success, auth-redirect, and marketplace-gate tests

### DIFF
--- a/tests/e2e/01-owner-signup.spec.ts
+++ b/tests/e2e/01-owner-signup.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { attachPageDiagnostics, signUpOwner, STRONG_PASSWORD, uniqueEmail } from './helpers';
 
 /**
- * T1 — Owner signup
+ * T1 — Owner signup + auth
  *
  * Validates:
  *   - /register accepts a new email/password/company
@@ -11,6 +11,9 @@ import { attachPageDiagnostics, signUpOwner, STRONG_PASSWORD, uniqueEmail } from
  *   - Navigating to /dashboard does not bounce to /login — i.e. the
  *     fb-id-token session cookie and the Firebase Auth client are in sync
  *     (the regression that PR #165's consolidated POST /api/register fixed)
+ *   - The login form rejects an unknown account without crashing
+ *   - An existing owner can sign out and log back in (login success path)
+ *   - An unauthenticated visitor is redirected away from /dashboard
  */
 
 test.describe('T1 — Owner signup', () => {
@@ -45,5 +48,35 @@ test.describe('T1 — Owner signup', () => {
     await page.waitForTimeout(4_000);
     await expect(page).not.toHaveURL(/\/dashboard/);
     await expect(page.getByText(/oops, something went wrong/i)).toHaveCount(0);
+  });
+
+  test('an owner who signs out can log back in and reach an authenticated page', async ({ page }) => {
+    // signUpOwner leaves the account created AND signed in on /create-profile.
+    const { email } = await signUpOwner(page);
+
+    // Sign out via the /register "Already Signed In" card.
+    await page.goto('/register');
+    await page.getByRole('button', { name: /sign out/i }).click();
+    // Signed out → /register falls back to the signup form.
+    await expect(page.getByRole('button', { name: /create company account/i })).toBeVisible({ timeout: 15_000 });
+
+    // Log back in with the same credentials the account was created with.
+    await page.goto('/login');
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByLabel(/password/i).fill(STRONG_PASSWORD);
+    await page.getByRole('button', { name: /^log ?in$|^sign ?in$/i }).click();
+
+    // A successful owner login hard-navigates into the authenticated area
+    // (/dashboard, or /create-profile if the profile is still incomplete).
+    // It must NOT stay on or bounce back to /login.
+    await page.waitForURL(/\/(dashboard|create-profile)/, { timeout: 30_000 });
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  test('an unauthenticated visitor is redirected from /dashboard to /login', async ({ page }) => {
+    // Fresh browser context — no fb-id-token cookie. The dashboard middleware
+    // must bounce an unauthenticated request to /login.
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
   });
 });

--- a/tests/e2e/03-post-load-matches.spec.ts
+++ b/tests/e2e/03-post-load-matches.spec.ts
@@ -11,7 +11,9 @@ import { attachPageDiagnostics, signUpOwner, reachDashboard } from './helpers';
  * attestations are missing.
  *
  * So for a fresh account the reliably-testable behaviour is: the gate
- * blocks them. That's a real, valuable regression check on #155.
+ * blocks them — at /dashboard/loads/new AND at /dashboard/matches (the
+ * match marketplace gate added in #170). That's a real, valuable
+ * regression check on the DEV-154 Layer-2 soft-compliance gate.
  *
  * The full "post a load → see it on /dashboard/loads → see it in Find
  * Match My Assets" happy path needs the profile attestations seeded first
@@ -34,6 +36,21 @@ test.describe('T3 — Load posting', () => {
     await expect(page.getByText(/complete your profile first/i)).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole('link', { name: /go to profile/i })).toBeVisible();
     await expect(page.getByLabel(/^origin/i)).toHaveCount(0);
+  });
+
+  test('a profile-incomplete owner is blocked from the match marketplace by the attestation gate', async ({ page }) => {
+    await signUpOwner(page);
+    await reachDashboard(page);
+
+    await page.goto('/dashboard/matches');
+
+    // #170 gate: the marketplace shows the same "Complete Your Profile First"
+    // blocking card as the load-post gate. The marketplace panels — and
+    // therefore the match-request buttons — must NOT render. The "My Assets"
+    // panel's description is a unique marker for that surface.
+    await expect(page.getByText(/complete your profile first/i)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('link', { name: /go to profile/i })).toBeVisible();
+    await expect(page.getByText(/select your load or driver to find matches/i)).toHaveCount(0);
   });
 
   // Needs an emulator seed step that writes profileInsurance +

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -37,9 +37,9 @@ npx playwright test tests/e2e/01-owner-signup.spec.ts   # Single spec
 
 | Spec | Validates |
 |---|---|
-| `01-owner-signup.spec.ts` | New owner can sign up, lands on `/create-profile`, navigating to `/dashboard` doesn't bounce to `/login` (the session-cookie/Auth desync regression). Login form rejects unknown accounts without crashing the error boundary. |
+| `01-owner-signup.spec.ts` | New owner can sign up, lands on `/create-profile`, navigating to `/dashboard` doesn't bounce to `/login` (the session-cookie/Auth desync regression). Login form rejects unknown accounts without crashing the error boundary. An owner can sign out and log back in (login success path). An unauthenticated visitor is redirected from `/dashboard` to `/login`. |
 | `02-self-driver-onboarding.spec.ts` | **Core:** OO can "Add Myself as Driver" and the record shows in the drivers list with the Owner-Driver badge. **`test.fixme`:** completing the full driver profile + Verified attestation — fixme'd because it drives runtime-dependent Radix `<Select>` markup; un-fixme once the suite runs green. |
-| `03-post-load-matches.spec.ts` | **Core:** a profile-incomplete owner is blocked from posting a load by the #155 attestation gate. **`test.fixme`:** full post-load → visible on `/dashboard/loads` + Find Match — fixme'd because it needs a profile-attestation emulator seed step. |
+| `03-post-load-matches.spec.ts` | **Core:** a profile-incomplete owner is blocked from posting a load AND from the match marketplace (`/dashboard/matches`) by the DEV-154 Layer-2 attestation gate. **`test.fixme`:** full post-load → visible on `/dashboard/loads` + Find Match — fixme'd because it needs a profile-attestation emulator seed step. |
 
 ## Known follow-ups (the `test.fixme` blocks)
 


### PR DESCRIPTION
## Summary
Strengthens E2E regression coverage on the **stable auth + gate surfaces** (the ones unlikely to churn while the product evolves). Takes the suite from **4 → 7 active tests**.

## New tests
1. **Login success path** (`01`) — an owner signs up, signs out via the `/register` "Already Signed In" card, then logs back in via `/login` and reaches an authenticated page. T1b only covered login *failure* (unknown account); the most-used flow in the app had no positive-path coverage.
2. **Auth redirect** (`01`) — an unauthenticated visitor hitting `/dashboard` is redirected to `/login`. A middleware regression check (T1a only covered the authenticated direction).
3. **Marketplace gate** (`03`) — a profile-incomplete owner is blocked from `/dashboard/matches` by the DEV-154 Layer-2 attestation gate. This is **direct coverage for the gate shipped in #170**, which had none — mirrors the existing load-post gate test.

## Changes
- `tests/e2e/01-owner-signup.spec.ts` — +2 tests, header updated.
- `tests/e2e/03-post-load-matches.spec.ts` — +1 test, header updated.
- `tests/e2e/README.md` — coverage table updated.
- No app code changed; all tests reuse the existing `signUpOwner` / `reachDashboard` helpers.

## Test Plan
- [ ] CI: the `Playwright + Firebase Emulators` check runs all 7 active tests green (2 `test.fixme` still skipped).
- Note: I could not browser-drive these locally (Playwright browsers can't be installed in the dev sandbox) — selectors were verified by reading `login/page.tsx`, `register/page.tsx`, and the `#170` matches-gate markup. If a selector is off, the `[browser:*]` diagnostics in the job log will show it.

https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJrAPyVerF2sm6brwgtu6f)_