### PR TITLE
White-glove pre-activation onboarding (DEV-158)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -47,7 +47,13 @@ service cloud.firestore {
     }
 
     match /owner_operators/{ownerOperatorId} {
-      allow get: if isSignedIn();
+      // Pre-activated accounts (white-glove onboarding, DEV-158) are readable
+      // only by their owner or an admin — never by other users.
+      allow get: if isSignedIn() && (
+        resource.data.get('accountStatus', 'active') != 'pre-activated' ||
+        isOwner(ownerOperatorId) ||
+        isAdmin()
+      );
       allow list: if isSignedIn();
       allow create: if isSignedIn() && isOwner(ownerOperatorId);
       // SECURITY FIX: Only owner can update their own profile
@@ -55,7 +61,13 @@ service cloud.firestore {
       allow delete: if isSignedIn() && (isOwner(ownerOperatorId) || isSuperAdmin());
 
       match /drivers/{driverId} {
-        allow read: if isSignedIn();
+        // Pre-activated drivers (DEV-158) are readable only by their owner
+        // or an admin.
+        allow get: if isSignedIn() && (
+          resource.data.get('accountStatus', 'active') != 'pre-activated' ||
+          isOwner(ownerOperatorId) ||
+          isAdmin()
+        );
         allow list: if isSignedIn();
         allow create: if isSignedIn() && isOwner(ownerOperatorId);
         allow update: if isSignedIn() && (isOwner(ownerOperatorId) || request.auth.uid == driverId || isAdmin());
@@ -146,6 +158,13 @@ service cloud.firestore {
       allow read: if isSignedIn() && isAdmin();
       allow create: if isSignedIn() && isAdmin();
       allow update, delete: if false;
+    }
+
+    // Activation tokens for white-glove pre-activation onboarding (DEV-158).
+    // One-time credentials — written and read only server-side via the Admin
+    // SDK (which bypasses rules). Never accessible to clients.
+    match /activation_tokens/{tokenId} {
+      allow read, write: if false;
     }
   }
 }

--- a/src/app/activate/page.tsx
+++ b/src/app/activate/page.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useState, FormEvent } from 'react';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Logo } from '@/components/logo';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useAuth } from '@/firebase';
+import { Loader2, Check, X, PartyPopper, Truck } from 'lucide-react';
+import { showSuccess, showError } from '@/lib/toast-utils';
+import { passwordSchema } from '@/lib/password-validation';
+
+interface ActivationInfo {
+  email: string;
+  recipientName: string | null;
+  companyName: string | null;
+  matchSummary: string | null;
+}
+
+function ActivateContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const auth = useAuth();
+  const token = searchParams.get('token') || '';
+
+  const [checking, setChecking] = useState(true);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [info, setInfo] = useState<ActivationInfo | null>(null);
+
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setTokenError('This activation link is missing its code.');
+      setChecking(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/activate?token=${encodeURIComponent(token)}`);
+        const data = await res.json().catch(() => ({}));
+        if (cancelled) return;
+        if (!res.ok || !data.valid) {
+          setTokenError(data.error || 'This activation link is not valid.');
+        } else {
+          setInfo({
+            email: data.email,
+            recipientName: data.recipientName,
+            companyName: data.companyName,
+            matchSummary: data.matchSummary,
+          });
+        }
+      } catch {
+        if (!cancelled) setTokenError('Could not validate this link. Please try again.');
+      } finally {
+        if (!cancelled) setChecking(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const passwordChecks = {
+    length: password.length >= 8,
+    uppercase: /[A-Z]/.test(password),
+    lowercase: /[a-z]/.test(password),
+    number: /[0-9]/.test(password),
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    if (!info) return;
+
+    const pw = passwordSchema.safeParse(password);
+    if (!pw.success) {
+      const message = pw.error.errors[0].message;
+      setError(message);
+      showError(message);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/activate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        const message = data?.error || 'Activation failed. Please try again.';
+        setError(message);
+        showError(message);
+        setSubmitting(false);
+        return;
+      }
+
+      // Sign in with the credentials we just set, then exchange the ID token
+      // for the session cookie — same pattern as /api/register.
+      const credential = await signInWithEmailAndPassword(auth, info.email, password);
+      const idToken = await credential.user.getIdToken();
+
+      const sessionRes = await fetch('/api/auth/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: idToken }),
+      });
+
+      if (!sessionRes.ok) {
+        showSuccess('Account activated. Please sign in to continue.');
+        router.push(
+          `/login?email=${encodeURIComponent(info.email)}&message=Account activated. Please log in to continue.`
+        );
+        return;
+      }
+
+      showSuccess('Welcome to XtraFleet!');
+      // Hard navigation so the next request carries the fresh session cookie.
+      window.location.href = '/dashboard';
+    } catch (err: unknown) {
+      const code = (err as { code?: string })?.code;
+      if (
+        code === 'auth/wrong-password' ||
+        code === 'auth/invalid-credential' ||
+        code === 'auth/user-not-found'
+      ) {
+        // The account was activated server-side; only the client sign-in
+        // failed. The user can still log in normally.
+        showSuccess('Account activated. Please sign in to continue.');
+        router.push(
+          `/login?email=${encodeURIComponent(info.email)}&message=Account activated. Please log in to continue.`
+        );
+        return;
+      }
+      console.error('Activation error:', err);
+      setError('An error occurred. Please try again.');
+      setSubmitting(false);
+    }
+  };
+
+  if (checking) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background p-4">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (tokenError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background p-4">
+        <Card className="mx-auto w-full max-w-sm">
+          <CardHeader className="space-y-4 text-center">
+            <Link href="/" passHref className="inline-block">
+              <Logo />
+            </Link>
+            <CardTitle className="font-headline text-2xl">Activation Link Problem</CardTitle>
+            <CardDescription>{tokenError}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-center text-sm text-muted-foreground">
+            <p>
+              Please contact your XtraFleet representative for a new link, or{' '}
+              <Link href="/login" className="underline">
+                sign in
+              </Link>{' '}
+              if your account is already set up.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="mx-auto w-full max-w-md">
+        <CardHeader className="space-y-4 text-center">
+          <Link href="/" passHref className="inline-block">
+            <Logo />
+          </Link>
+          <div className="flex items-center justify-center gap-2 text-primary">
+            <PartyPopper className="h-5 w-5" />
+            <span className="text-sm font-medium">
+              Welcome{info?.recipientName ? `, ${info.recipientName}` : ''}
+            </span>
+          </div>
+          <CardTitle className="font-headline text-2xl">Activate Your Account</CardTitle>
+          <CardDescription>
+            {info?.companyName
+              ? `Set a password to access the XtraFleet account for ${info.companyName}.`
+              : 'Set a password to access your XtraFleet account.'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {info?.matchSummary && (
+            <div className="mb-4 rounded-lg border border-primary/30 bg-primary/5 p-3">
+              <div className="flex items-start gap-2">
+                <Truck className="mt-0.5 h-4 w-4 text-primary" />
+                <div className="text-sm">
+                  <p className="font-medium">You have a match waiting</p>
+                  <p className="text-muted-foreground">{info.matchSummary}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" type="email" value={info?.email || ''} disabled readOnly />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="password">Choose a Password *</Label>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  required
+                  disabled={submitting}
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+                {password && (
+                  <div className="mt-2 space-y-1">
+                    <p className="mb-1 text-xs text-muted-foreground">Password must have:</p>
+                    {[
+                      { label: 'At least 8 characters', met: passwordChecks.length },
+                      { label: 'One uppercase letter', met: passwordChecks.uppercase },
+                      { label: 'One lowercase letter', met: passwordChecks.lowercase },
+                      { label: 'One number', met: passwordChecks.number },
+                    ].map((req, idx) => (
+                      <div key={idx} className="flex items-center gap-2 text-xs">
+                        {req.met ? (
+                          <Check className="h-3 w-3 text-green-600" />
+                        ) : (
+                          <X className="h-3 w-3 text-muted-foreground" />
+                        )}
+                        <span className={req.met ? 'text-green-600' : 'text-muted-foreground'}>
+                          {req.label}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <Button type="submit" className="w-full" disabled={submitting}>
+                {submitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Activating...
+                  </>
+                ) : (
+                  'Activate & Sign In'
+                )}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function ActivatePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin" />
+        </div>
+      }
+    >
+      <ActivateContent />
+    </Suspense>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -28,7 +28,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Logo } from "@/components/logo";
-import { Home, Users, Truck, LogOut, Loader2, FileText, Link2, Shield, ClipboardList, Package, Settings, CreditCard } from "lucide-react";
+import { Home, Users, Truck, LogOut, Loader2, FileText, Link2, Shield, ClipboardList, Package, Settings, CreditCard, UserPlus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -80,6 +80,11 @@ function AdminSidebarNav({ onSignOutClick, adminRole }: { onSignOutClick: () => 
           {checkPermission('users:view') && (
             <SidebarMenuItem>
               <AdminSidebarNavLink href="/admin/users" tooltip="Users"><Users /><span>Users (OOs)</span></AdminSidebarNavLink>
+            </SidebarMenuItem>
+          )}
+          {checkPermission('users:create') && (
+            <SidebarMenuItem>
+              <AdminSidebarNavLink href="/admin/onboard" tooltip="Onboard Customer"><UserPlus /><span>Onboard Customer</span></AdminSidebarNavLink>
             </SidebarMenuItem>
           )}
           {checkPermission('drivers:view') && (

--- a/src/app/admin/onboard/page.tsx
+++ b/src/app/admin/onboard/page.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Loader2, UserPlus, Copy, CheckCircle2 } from 'lucide-react';
+import { showSuccess, showError } from '@/lib/toast-utils';
+import { useAdminRole } from '../layout';
+
+interface OnboardResult {
+  ownerOperatorId: string;
+  activationUrl: string;
+  expiresAt: string;
+  carrier: { legalName?: string; authorityStatus?: string; allowedToOperate: boolean };
+}
+
+export default function AdminOnboardPage() {
+  const { hasPermission } = useAdminRole();
+  const canOnboard = hasPermission('users:create');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<OnboardResult | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const form = new FormData(event.currentTarget);
+    const payload = {
+      companyName: String(form.get('companyName') || ''),
+      legalName: String(form.get('legalName') || ''),
+      contactName: String(form.get('contactName') || ''),
+      contactEmail: String(form.get('contactEmail') || ''),
+      phone: String(form.get('phone') || ''),
+      dotNumber: String(form.get('dotNumber') || ''),
+      mcNumber: String(form.get('mcNumber') || ''),
+      address: String(form.get('address') || ''),
+      city: String(form.get('city') || ''),
+      state: String(form.get('state') || ''),
+      zip: String(form.get('zip') || ''),
+    };
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/admin/onboard', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const message = data?.error || 'Failed to pre-register the customer.';
+        setError(message);
+        showError(message);
+        setSubmitting(false);
+        return;
+      }
+      setResult(data as OnboardResult);
+      showSuccess('Customer pre-registered.');
+    } catch (err) {
+      console.error('Onboard error:', err);
+      const message = 'An unexpected error occurred. Please try again.';
+      setError(message);
+      showError(message);
+      setSubmitting(false);
+    }
+  };
+
+  const copyLink = async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result.activationUrl);
+      showSuccess('Activation link copied.');
+    } catch {
+      showError('Could not copy automatically — select and copy the link manually.');
+    }
+  };
+
+  if (!canOnboard) {
+    return (
+      <Card className="mx-auto max-w-lg">
+        <CardHeader>
+          <CardTitle>No access</CardTitle>
+          <CardDescription>Your admin role can&apos;t pre-register customers.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (result) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CheckCircle2 className="h-5 w-5 text-green-600" />
+              Customer Pre-registered
+            </CardTitle>
+            <CardDescription>
+              The account is created and pre-activated. Run a match for this customer, then
+              send them the activation link below so they can set a password and sign in.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-lg border bg-muted/40 p-3 text-sm space-y-1">
+              <p>
+                <span className="text-muted-foreground">Account ID:</span>{' '}
+                <code className="text-xs">{result.ownerOperatorId}</code>
+              </p>
+              <p>
+                <span className="text-muted-foreground">FMCSA:</span>{' '}
+                {result.carrier.legalName || 'Verified'} — authority{' '}
+                {result.carrier.authorityStatus || 'unknown'}
+              </p>
+            </div>
+            <div className="grid gap-2">
+              <Label>
+                Activation link (expires {new Date(result.expiresAt).toLocaleDateString()})
+              </Label>
+              <div className="flex gap-2">
+                <Input readOnly value={result.activationUrl} className="font-mono text-xs" />
+                <Button type="button" variant="outline" onClick={copyLink}>
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setResult(null);
+                setError(null);
+                setSubmitting(false);
+              }}
+            >
+              Onboard another customer
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UserPlus className="h-5 w-5" />
+            Onboard a Customer
+          </CardTitle>
+          <CardDescription>
+            Pre-register a fleet on the customer&apos;s behalf using the details collected
+            over the phone. The carrier is verified against FMCSA and a one-time activation
+            link is generated.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="grid gap-5">
+            <div className="grid gap-4">
+              <p className="text-sm font-medium text-muted-foreground">Company</p>
+              <div className="grid gap-2">
+                <Label htmlFor="companyName">Company Name *</Label>
+                <Input id="companyName" name="companyName" required disabled={submitting} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="legalName">Legal Name</Label>
+                <Input
+                  id="legalName"
+                  name="legalName"
+                  placeholder="Defaults to the FMCSA legal name"
+                  disabled={submitting}
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-2">
+                  <Label htmlFor="dotNumber">DOT Number *</Label>
+                  <Input id="dotNumber" name="dotNumber" required disabled={submitting} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="mcNumber">MC Number</Label>
+                  <Input id="mcNumber" name="mcNumber" disabled={submitting} />
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-4 border-t pt-4">
+              <p className="text-sm font-medium text-muted-foreground">Contact</p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-2">
+                  <Label htmlFor="contactName">Contact Name *</Label>
+                  <Input id="contactName" name="contactName" required disabled={submitting} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="phone">Phone</Label>
+                  <Input id="phone" name="phone" type="tel" disabled={submitting} />
+                </div>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="contactEmail">Contact Email *</Label>
+                <Input
+                  id="contactEmail"
+                  name="contactEmail"
+                  type="email"
+                  required
+                  disabled={submitting}
+                />
+                <p className="text-xs text-muted-foreground">
+                  The activation link will be sent here. Must not already be a XtraFleet account.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 border-t pt-4">
+              <p className="text-sm font-medium text-muted-foreground">
+                Address <span className="font-normal">(optional — filled from FMCSA if blank)</span>
+              </p>
+              <div className="grid gap-2">
+                <Label htmlFor="address">Street Address</Label>
+                <Input id="address" name="address" disabled={submitting} />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-3">
+                <div className="grid gap-2">
+                  <Label htmlFor="city">City</Label>
+                  <Input id="city" name="city" disabled={submitting} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="state">State</Label>
+                  <Input id="state" name="state" disabled={submitting} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="zip">ZIP</Label>
+                  <Input id="zip" name="zip" disabled={submitting} />
+                </div>
+              </div>
+            </div>
+
+            <Button type="submit" disabled={submitting} className="w-full">
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Verifying with FMCSA &amp; creating account...
+                </>
+              ) : (
+                'Pre-register Customer'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/activate/route.ts
+++ b/src/app/api/activate/route.ts
@@ -1,0 +1,184 @@
+/**
+ * Activation endpoint for white-glove pre-activation onboarding (DEV-158).
+ *
+ * GET  /api/activate?token=...  — validate a token, return prefill info for
+ *                                 the activation page (does NOT consume it).
+ * POST /api/activate            — { token, password }: create the Firebase
+ *                                 Auth user, flip the account to active, and
+ *                                 consume the one-time token.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirebaseAdmin } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { rateLimiters, getIdentifier, formatTimeRemaining } from '@/lib/rate-limit';
+import { passwordSchema } from '@/lib/password-validation';
+import { hashActivationToken } from '@/lib/activation-tokens';
+
+type AdminDb = Awaited<ReturnType<typeof getFirebaseAdmin>>['db'];
+
+interface ActivationTokenDoc {
+  ownerOperatorId: string;
+  email: string;
+  companyName?: string;
+  recipientName?: string;
+  matchSummary?: string;
+  createdByAdmin: string;
+  createdAt: string;
+  expiresAt: string;
+  consumedAt?: string;
+}
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+/** Load a token by its raw value and check it is unused and unexpired. */
+async function loadValidToken(
+  db: AdminDb,
+  rawToken: string
+): Promise<
+  | { error: string; status: number }
+  | { tokenId: string; data: ActivationTokenDoc }
+> {
+  const tokenId = hashActivationToken(rawToken);
+  const snap = await db.collection('activation_tokens').doc(tokenId).get();
+  if (!snap.exists) {
+    return { error: 'This activation link is not valid.', status: 404 };
+  }
+  const data = snap.data() as ActivationTokenDoc;
+  if (data.consumedAt) {
+    return { error: 'This activation link has already been used.', status: 410 };
+  }
+  if (new Date(data.expiresAt).getTime() < Date.now()) {
+    return {
+      error: 'This activation link has expired. Please ask your XtraFleet contact for a new one.',
+      status: 410,
+    };
+  }
+  return { tokenId, data };
+}
+
+async function handleGet(request: NextRequest) {
+  try {
+    const rawToken = request.nextUrl.searchParams.get('token');
+    if (!rawToken) {
+      return json({ valid: false, error: 'This activation link is missing its code.' }, 400);
+    }
+
+    const { db } = await getFirebaseAdmin();
+    const result = await loadValidToken(db, rawToken);
+    if ('error' in result) {
+      return json({ valid: false, error: result.error }, result.status);
+    }
+
+    const { data } = result;
+    return json(
+      {
+        valid: true,
+        email: data.email,
+        companyName: data.companyName ?? null,
+        recipientName: data.recipientName ?? null,
+        matchSummary: data.matchSummary ?? null,
+      },
+      200
+    );
+  } catch (error) {
+    console.error('[GET /api/activate]', error);
+    return json({ valid: false, error: 'Could not validate this link. Please try again.' }, 500);
+  }
+}
+
+async function handlePost(request: NextRequest) {
+  // Rate limit by IP — defense in depth against token guessing.
+  const { success, reset } = await rateLimiters.activation.limit(getIdentifier(request));
+  if (!success) {
+    return json(
+      { error: `Too many activation attempts. Please try again in ${formatTimeRemaining(reset)}.` },
+      429
+    );
+  }
+
+  try {
+    let body: { token?: unknown; password?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: 'Invalid request body.' }, 400);
+    }
+    const rawToken = typeof body.token === 'string' ? body.token : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+    if (!rawToken) {
+      return json({ error: 'This activation link is missing its code.' }, 400);
+    }
+
+    const pw = passwordSchema.safeParse(password);
+    if (!pw.success) {
+      return json({ error: pw.error.errors[0]?.message || 'Password does not meet requirements.' }, 400);
+    }
+
+    const { auth, db } = await getFirebaseAdmin();
+
+    const result = await loadValidToken(db, rawToken);
+    if ('error' in result) {
+      return json({ error: result.error }, result.status);
+    }
+    const { tokenId, data } = result;
+
+    // The pre-activated account must still exist and not be activated yet.
+    const ooRef = db.collection('owner_operators').doc(data.ownerOperatorId);
+    const ooSnap = await ooRef.get();
+    if (!ooSnap.exists) {
+      return json({ error: 'The account for this link no longer exists.' }, 404);
+    }
+    const oo = ooSnap.data() as { accountStatus?: string };
+    if (oo.accountStatus !== 'pre-activated') {
+      return json({ error: 'This account has already been activated.' }, 409);
+    }
+
+    // Create the Firebase Auth user with uid == the pre-activated doc id, so
+    // every existing rule and match/TLA reference keyed on that id stays valid.
+    try {
+      await auth.createUser({
+        uid: data.ownerOperatorId,
+        email: data.email,
+        password,
+        emailVerified: true,
+      });
+    } catch (err: unknown) {
+      const code =
+        (err as { errorInfo?: { code?: string } })?.errorInfo?.code ||
+        (err as { code?: string })?.code ||
+        '';
+      if (code === 'auth/uid-already-exists' || code === 'auth/email-already-exists') {
+        return json({ error: 'This account has already been activated.' }, 409);
+      }
+      if (code === 'auth/invalid-password') {
+        return json({ error: 'Password does not meet security requirements.' }, 400);
+      }
+      throw err;
+    }
+
+    const now = new Date().toISOString();
+
+    // Flip the account to active.
+    await ooRef.update({ accountStatus: 'active', activatedAt: now });
+
+    // Role document — mirrors what /api/register writes for a normal signup.
+    await db.collection('users').doc(data.ownerOperatorId).set({
+      role: 'owner_operator',
+      email: data.email,
+      createdAt: now,
+    });
+
+    // Consume the token — one-time use.
+    await db.collection('activation_tokens').doc(tokenId).update({ consumedAt: now });
+
+    return json({ success: true, email: data.email }, 200);
+  } catch (error) {
+    console.error('[POST /api/activate]', error);
+    return json({ error: 'An unexpected error occurred during activation.' }, 500);
+  }
+}
+
+export const GET = withCors(handleGet);
+export const POST = withCors(handlePost);

--- a/src/app/api/admin/onboard/route.ts
+++ b/src/app/api/admin/onboard/route.ts
@@ -1,0 +1,200 @@
+/**
+ * Admin pre-registration endpoint — white-glove onboarding (DEV-158 part 2).
+ *
+ * An admin pre-registers a customer's fleet on their behalf: this verifies the
+ * carrier against FMCSA, creates a pre-activated owner_operators account, and
+ * issues a one-time activation token. The activation link is returned to the
+ * admin UI; the customer later claims the account via /activate.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+import { lookupByDOT } from '@/lib/fmcsa';
+import {
+  generateActivationToken,
+  hashActivationToken,
+  ACTIVATION_TOKEN_TTL_DAYS,
+} from '@/lib/activation-tokens';
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://xtrafleet.com';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+const bodySchema = z.object({
+  companyName: z.string().trim().min(1, 'Company name is required'),
+  legalName: z.string().trim().optional(),
+  contactName: z.string().trim().min(1, 'Contact name is required'),
+  contactEmail: z.string().trim().email('A valid contact email is required'),
+  phone: z.string().trim().optional(),
+  dotNumber: z.string().trim().min(1, 'DOT number is required'),
+  mcNumber: z.string().trim().optional(),
+  address: z.string().trim().optional(),
+  city: z.string().trim().optional(),
+  state: z.string().trim().optional(),
+  zip: z.string().trim().optional(),
+});
+
+async function handlePost(request: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+
+    // 1. Authenticate.
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+    const adminEmail = decoded.email || '';
+
+    // 2. Authorize — admin with the users:create permission.
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'users:create')) {
+      return json({ error: 'You do not have permission to onboard customers.' }, 403);
+    }
+
+    // 3. Validate input.
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return json({ error: 'Invalid request body.' }, 400);
+    }
+    const parsed = bodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return json(
+        {
+          error:
+            Object.values(parsed.error.flatten().fieldErrors).flat().join(', ') ||
+            'Invalid input.',
+        },
+        400
+      );
+    }
+    const input = parsed.data;
+
+    // 4. Reject if the contact email already belongs to a real account —
+    //    otherwise the pre-activated account could never be activated.
+    try {
+      await auth.getUserByEmail(input.contactEmail);
+      return json({ error: 'An account with this email already exists.' }, 409);
+    } catch (err: unknown) {
+      const code =
+        (err as { code?: string })?.code ||
+        (err as { errorInfo?: { code?: string } })?.errorInfo?.code ||
+        '';
+      if (code !== 'auth/user-not-found') throw err;
+    }
+
+    // 5. Verify the carrier against FMCSA (same source as normal onboarding).
+    const fmcsa = await lookupByDOT(input.dotNumber);
+    if (!fmcsa.success || !fmcsa.carrier) {
+      return json(
+        { error: `FMCSA verification failed: ${fmcsa.error || 'carrier not found'}.` },
+        422
+      );
+    }
+    const carrier = fmcsa.carrier;
+
+    const now = new Date().toISOString();
+
+    // 6. Create the pre-activated account. The doc id is generated now and
+    //    becomes the Firebase Auth uid at activation time.
+    const ooRef = db.collection('owner_operators').doc();
+    const ownerOperatorId = ooRef.id;
+
+    await ooRef.set({
+      id: ownerOperatorId,
+      companyName: input.companyName,
+      legalName: input.legalName || carrier.legalName || input.companyName,
+      contactName: input.contactName,
+      contactEmail: input.contactEmail,
+      phone: input.phone || carrier.phone || '',
+      dotNumber: input.dotNumber,
+      mcNumber: input.mcNumber || carrier.mcNumber || '',
+      address: input.address || carrier.hqAddress || '',
+      city: input.city || carrier.hqCity || '',
+      state: input.state || carrier.hqState || '',
+      zip: input.zip || carrier.hqZip || '',
+      subscriptionStatus: 'inactive',
+      accountStatus: 'pre-activated',
+      createdByAdmin: adminUid,
+      createdAt: now,
+      onboardingStatus: {
+        profileComplete: true,
+        fmcsaDesignated: false,
+        completedAt: now,
+      },
+      attestations: [],
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    // 7. Issue the one-time activation token (stored hashed).
+    const rawToken = generateActivationToken();
+    const expiresAt = new Date(
+      Date.now() + ACTIVATION_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000
+    ).toISOString();
+    await db
+      .collection('activation_tokens')
+      .doc(hashActivationToken(rawToken))
+      .set({
+        ownerOperatorId,
+        email: input.contactEmail,
+        companyName: input.companyName,
+        recipientName: input.contactName,
+        createdByAdmin: adminUid,
+        createdAt: now,
+        expiresAt,
+      });
+
+    // 8. Audit.
+    await db.collection('admin_audit').add({
+      action: 'pre_registered_account',
+      adminId: adminUid,
+      adminEmail,
+      targetType: 'owner_operator',
+      targetId: ownerOperatorId,
+      details: { companyName: input.companyName, dotNumber: input.dotNumber },
+      timestamp: now,
+    });
+
+    return json(
+      {
+        success: true,
+        ownerOperatorId,
+        activationUrl: `${APP_URL}/activate?token=${rawToken}`,
+        expiresAt,
+        carrier: {
+          legalName: carrier.legalName,
+          authorityStatus: carrier.authorityStatus,
+          allowedToOperate: carrier.allowedToOperate ?? false,
+        },
+      },
+      200
+    );
+  } catch (error) {
+    console.error('[POST /api/admin/onboard]', error);
+    return json(
+      { error: 'An unexpected error occurred while pre-registering the account.' },
+      500
+    );
+  }
+}
+
+export const POST = withCors(handlePost);

--- a/src/app/api/matches/accept/route.ts
+++ b/src/app/api/matches/accept/route.ts
@@ -17,6 +17,7 @@ import { rateLimiters, getIdentifier, formatTimeRemaining } from '@/lib/rate-lim
 import { runComplianceGate } from '@/lib/compliance-gate';
 import { generateTLA } from '@/lib/tla';
 import type { Match, OwnerOperator, Driver } from '@/lib/data';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
 
 function json(body: Record<string, unknown>, status: number) {
   return NextResponse.json(body, { status });
@@ -44,15 +45,21 @@ async function handlePost(request: NextRequest) {
 
   try {
     // 3. Validate input.
-    let matchId: unknown;
+    let rawBody: { matchId?: unknown; actingOnBehalfOf?: unknown };
     try {
-      matchId = (await request.json())?.matchId;
+      rawBody = await request.json();
     } catch {
       return json({ error: 'Invalid request body.' }, 400);
     }
+    const matchId = rawBody.matchId;
     if (!matchId || typeof matchId !== 'string') {
       return json({ error: 'A matchId is required.' }, 400);
     }
+    // Optional: an admin forming the match on behalf of a party (DEV-158).
+    const actingOnBehalfOf =
+      typeof rawBody.actingOnBehalfOf === 'string' && rawBody.actingOnBehalfOf
+        ? rawBody.actingOnBehalfOf
+        : undefined;
 
     const { db } = await getFirebaseAdmin();
 
@@ -63,8 +70,29 @@ async function handlePost(request: NextRequest) {
     }
     const match = { id: matchId, ...(matchSnap.data() as Omit<Match, 'id'>) } as Match;
 
-    // 5. Authorize — the caller must be a party to the match.
-    if (user.uid !== match.loadOwnerId && user.uid !== match.driverOwnerId) {
+    // 5. Authorize. Normally the caller must be a party to the match. With
+    //    actingOnBehalfOf (white-glove onboarding, DEV-158) an authorized
+    //    admin forms the match on behalf of a party — the compliance gate
+    //    below still fires identically; there is no admin shortcut.
+    if (actingOnBehalfOf) {
+      const adminSnap = await db.collection('owner_operators').doc(user.uid).get();
+      const adminData = adminSnap.exists ? adminSnap.data() : null;
+      const role: AdminRole | undefined = adminData?.isAdmin
+        ? ((adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin())
+        : undefined;
+      if (!role || !hasPermission(role, 'users:create')) {
+        return json(
+          { error: 'Only an authorized admin can act on behalf of another user.' },
+          403
+        );
+      }
+      if (actingOnBehalfOf !== match.loadOwnerId && actingOnBehalfOf !== match.driverOwnerId) {
+        return json(
+          { error: 'The on-behalf-of user is not a participant in this match.' },
+          403
+        );
+      }
+    } else if (user.uid !== match.loadOwnerId && user.uid !== match.driverOwnerId) {
       return json({ error: 'You are not a participant in this match.' }, 403);
     }
 
@@ -122,6 +150,8 @@ async function handlePost(request: NextRequest) {
 
     const auditBase = {
       userId: user.uid,
+      formedBy: user.uid,
+      ...(actingOnBehalfOf ? { onBehalfOf: actingOnBehalfOf } : {}),
       matchId,
       loadId: match.loadId,
       loadOwnerId: match.loadOwnerId,
@@ -165,7 +195,9 @@ async function handlePost(request: NextRequest) {
       status: 'tla_pending',
       tlaId: tlaRef.id,
       complianceWarning,
+      formedBy: user.uid,
     };
+    if (actingOnBehalfOf) matchUpdate.onBehalfOf = actingOnBehalfOf;
     if (isCounter) {
       matchUpdate.counterAcceptedAt = now;
       matchUpdate.finalTerms = match.counterTerms;

--- a/src/lib/activation-tokens.ts
+++ b/src/lib/activation-tokens.ts
@@ -1,0 +1,22 @@
+/**
+ * Activation tokens for white-glove pre-activation onboarding (DEV-158).
+ *
+ * A pre-activated account is claimed via a one-time activation link. The raw
+ * token only ever travels in the activation email / URL; Firestore stores only
+ * its SHA-256 hash (as the activation_tokens doc id), so a leaked database read
+ * cannot be turned into a working link.
+ */
+import { randomBytes, createHash } from 'crypto';
+
+/** How long an activation link stays valid. */
+export const ACTIVATION_TOKEN_TTL_DAYS = 14;
+
+/** Generate an opaque, URL-safe one-time activation token. */
+export function generateActivationToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/** Hash a raw token into the value stored as the activation_tokens doc id. */
+export function hashActivationToken(rawToken: string): string {
+  return createHash('sha256').update(rawToken).digest('hex');
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -188,6 +188,7 @@ export type OwnerOperator = {
   id: string;
   companyName?: string;
   legalName?: string;
+  contactName?: string;
   contactEmail: string;
   phone?: string;
   address?: string;

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -8,6 +8,14 @@ export type Review = {
   comment: string;
 };
 
+// Where an account sits in the white-glove pre-activation lifecycle (DEV-158).
+// Absent on legacy accounts — code reading this should treat a missing value
+// as 'active'.
+export type AccountStatus =
+  | 'pre-activated' // admin-created on the user's behalf; no auth credentials yet
+  | 'active'        // fully activated, has Firebase Auth credentials
+  | 'suspended';    // disabled
+
 export type Driver = {
   id: string;
   name: string;
@@ -61,6 +69,10 @@ export type Driver = {
   // Contact
   phoneNumber?: string;
   phone?: string;
+  // Account lifecycle — white-glove pre-activation onboarding (DEV-158).
+  accountStatus?: AccountStatus;
+  createdByAdmin?: string; // admin UID, when created on the user's behalf
+  activatedAt?: string;    // ISO timestamp the user completed activation
 };
 
 export type Load = {
@@ -199,6 +211,10 @@ export type OwnerOperator = {
     coiDocumentUrl?: string;
     coiDocumentUploadedAt?: string;
   };
+  // Account lifecycle — white-glove pre-activation onboarding (DEV-158).
+  accountStatus?: AccountStatus;
+  createdByAdmin?: string; // admin UID, when created on the user's behalf
+  activatedAt?: string;    // ISO timestamp the user completed activation
 };
 
 export type TLASignature = {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -118,6 +118,38 @@ export async function sendOwnerProfileCompleteEmail(email: string, companyName: 
   return sendEmail(email, subject, html);
 }
 
+// ==================== ACTIVATION EMAIL (white-glove pre-activation) ====================
+
+export async function sendActivationEmail(
+  email: string,
+  recipientName: string,
+  activationUrl: string,
+  matchSummary?: string
+) {
+  const subject = 'Your XtraFleet account is ready — set your password';
+  const html = emailTemplate(`
+    <h2 style="color: #1a1a1a; font-size: 20px; margin-bottom: 16px;">Welcome to XtraFleet, ${recipientName}!</h2>
+
+    <p>Your XtraFleet account has been set up for you${matchSummary ? ' &mdash; and you already have a load match waiting' : ''}.</p>
+
+    ${matchSummary ? `<div style="background-color: #f0f9ff; border-left: 4px solid #1E9BD7; padding: 12px 16px; margin: 20px 0; border-radius: 4px;">
+      <p style="margin: 0; color: #1a1a1a;"><strong>Your match:</strong> ${matchSummary}</p>
+    </div>` : ''}
+
+    <p>To access your account${matchSummary ? ' and review your match' : ''}, set a password:</p>
+
+    <div style="text-align: center; margin: 32px 0;">
+      <a href="${activationUrl}" style="${buttonStyle()}">
+        Set Your Password
+      </a>
+    </div>
+
+    <p style="color: #6b7280; font-size: 14px;">This link is unique to you and expires in 14 days. If you didn't expect this email, you can safely ignore it.</p>
+  `);
+
+  return sendEmail(email, subject, html);
+}
+
 // ==================== DRIVER EMAILS ====================
 
 export async function sendDriverInvitationConfirmationEmail(

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -54,6 +54,9 @@ export const rateLimiters = {
 
   // Match formation (compliance-gated accept): 30 per hour per user
   matchFormation: makeLimiter(30, '1 h', 'ratelimit:matchFormation'),
+
+  // Account activation: 10 per hour per IP (defense against token guessing)
+  activation: makeLimiter(10, '1 h', 'ratelimit:activation'),
 };
 
 // Helper function to get client identifier (IP or user ID)


### PR DESCRIPTION
## Summary
White-glove pre-activation onboarding (DEV-158) — lets an admin pre-register a customer, run a real compliance-gated match for them, and hand over an activation link so the customer sets a password and lands signed in on a pre-populated dashboard.

## Progress — all 4 parts complete
- [x] Part 1 — Data model + Firestore rules
- [x] Part 2 — Admin pre-registration page + API
- [x] Part 3 — Admin-on-behalf-of match formation
- [x] Part 4 — Activation flow

## What's in each part
**Part 1 — Data model + rules**
- `AccountStatus` (`pre-activated | active | suspended`) plus `accountStatus` / `createdByAdmin` / `activatedAt` / `contactName` on `OwnerOperator` and `Driver`. All optional — legacy accounts read as `active`.
- Firestore rules: pre-activated accounts readable only by owner/admin; new locked `activation_tokens` collection.

**Part 4 — Activation flow**
- `/activate` page + `GET`/`POST /api/activate`. POST creates the Firebase Auth user with `uid` == the pre-activated doc id (so existing rules and match/TLA references stay valid), flips `accountStatus` to `active`, and consumes the one-time token.
- `activation-tokens` lib (opaque token + SHA-256 hashing), `sendActivationEmail` template, activation rate limiter.

**Part 2 — Admin pre-registration**
- `/admin/onboard` page + `POST /api/admin/onboard`. Admin-gated (`users:create`), verifies the carrier against FMCSA, creates a pre-activated account, issues the activation token, returns the link. Adds an "Onboard Customer" entry to the admin sidebar.

**Part 3 — Admin-on-behalf-of match formation**
- `POST /api/matches/accept` gains an optional `actingOnBehalfOf` parameter — admin-only (`users:create`), must name a party to the match. The synchronous compliance gate fires identically — no admin shortcut. `formedBy` / `onBehalfOf` recorded on the match record and the audit log.

## Notes / deviations
- Activation tokens live in a locked `activation_tokens` collection (stored hashed), not as fields on the user doc — so the one-time credential can't leak via a list query.
- The activation email is sent by the admin using the returned link (the ticket's "email composition" step); `sendActivationEmail` is the stored template. Auto-send is a small follow-up if wanted.
- On-behalf creation of the *pending* match (the request, before accept) still uses the existing flow — Phase 3 of the ticket covers the *formation*/accept path.
- Admin-uploaded compliance documents (a Phase 2 sub-item) are deferred: the customer uploads docs after activation, and the compliance gate blocks on FMCSA authority rather than uploaded docs.

## Setup Required
- When this reaches QA/production, publish `firestore.rules` manually (tracked in DEV-163).

## Test Plan
- [ ] Pre-register a customer via `/admin/onboard` → activation link returned
- [ ] Activate via the link → password set, lands signed in on the dashboard
- [ ] Expired / used / invalid token → clear error
- [ ] Admin forms a match with `actingOnBehalfOf` → compliance gate still fires; `formedBy`/`onBehalfOf` recorded
- [ ] Non-admin passing `actingOnBehalfOf` → 403
- [ ] Existing accounts (no `accountStatus`) unaffected
- [ ] CI: Next.js build + Playwright/emulators green

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA