### PR TITLE
Attestation UX polish + auto-email on admin pre-registration

### DIFF
--- a/src/app/api/admin/onboard/route.ts
+++ b/src/app/api/admin/onboard/route.ts
@@ -12,6 +12,7 @@ import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
 import { withCors } from '@/lib/api-cors';
 import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
 import { lookupByDOT } from '@/lib/fmcsa';
+import { sendActivationEmail } from '@/lib/email';
 import {
   generateActivationToken,
   hashActivationToken,
@@ -163,7 +164,15 @@ async function handlePost(request: NextRequest) {
         expiresAt,
       });
 
-    // 8. Audit.
+    const activationUrl = `${APP_URL}/activate?token=${rawToken}`;
+
+    // 8. Email the activation link to the customer (best-effort — the admin
+    //    still gets the link in the response as a backup).
+    sendActivationEmail(input.contactEmail, input.contactName, activationUrl).catch(err =>
+      console.error('[admin/onboard] activation email failed', err)
+    );
+
+    // 9. Audit.
     await db.collection('admin_audit').add({
       action: 'pre_registered_account',
       adminId: adminUid,
@@ -178,7 +187,7 @@ async function handlePost(request: NextRequest) {
       {
         success: true,
         ownerOperatorId,
-        activationUrl: `${APP_URL}/activate?token=${rawToken}`,
+        activationUrl,
         expiresAt,
         carrier: {
           legalName: carrier.legalName,

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -967,7 +967,7 @@ export default function ProfilePage() {
                         <CheckCircle2 className={`h-4 w-4 mt-0.5 shrink-0 ${stale ? 'text-amber-500' : 'text-green-600'}`} />
                         <div className="flex-1">
                           <p className="text-sm font-medium">
-                            {entry.type}
+                            {def?.label || entry.type}
                             <span className="ml-2 text-xs text-muted-foreground font-normal">
                               v{entry.version}{stale && ` (current: v${def.v})`}
                             </span>

--- a/src/components/attestation-recapture-sheet.tsx
+++ b/src/components/attestation-recapture-sheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -44,12 +45,14 @@ export function AttestationRecaptureSheet({
   onOpenChange,
   onCaptured,
 }: AttestationRecaptureSheetProps) {
-  const [checked, setChecked] = useState<Set<AttestationType>>(new Set(missingTypes));
+  // Start unchecked — the user actively opts in to each attestation. Pre-checking
+  // would weaken the legal force of the consent.
+  const [checked, setChecked] = useState<Set<AttestationType>>(new Set());
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (open) {
-      setChecked(new Set(missingTypes));
+      setChecked(new Set());
     }
   }, [open, missingTypes]);
 
@@ -143,12 +146,22 @@ export function AttestationRecaptureSheet({
                 />
                 <div className="space-y-1">
                   <Label htmlFor={`attest-${type}`} className="cursor-pointer text-sm font-medium">
-                    {type}
+                    {def.label}
                     {!isMissing && (
                       <span className="ml-2 text-xs text-muted-foreground">(already on file)</span>
                     )}
                   </Label>
                   <p className="text-xs text-muted-foreground leading-relaxed">{def.text}</p>
+                  {def.legalLink && (
+                    <Link
+                      href={def.legalLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-primary underline hover:no-underline"
+                    >
+                      Read the full text
+                    </Link>
+                  )}
                 </div>
               </div>
             );

--- a/src/lib/attestations.ts
+++ b/src/lib/attestations.ts
@@ -51,8 +51,16 @@ export type AttestationType =
 export interface AttestationDef {
   /** Current version. Bumped only on material wording changes. */
   v: number;
+  /** Short, human-readable title for the UI (e.g. "Insurance Coverage"). */
+  label: string;
   /** Exact text shown to the user. Snapshotted into each AttestationEntry on accept. */
   text: string;
+  /**
+   * Optional link to the public legal page that backs this attestation
+   * (e.g. /legal/terms). Only signup / e-sign attestations have one — the
+   * rest are factual assertions about the carrier's own operations.
+   */
+  legalLink?: string;
   /** Where this attestation is captured. Used by audit views. */
   surface:
     | 'signup'
@@ -72,102 +80,123 @@ export interface AttestationDef {
 export const ATTESTATIONS: Record<AttestationType, AttestationDef> = {
   signupAuthorized: {
     v: 1,
+    label: 'Authorized to Act',
     text: 'I confirm I am authorized to act on behalf of this company.',
     surface: 'signup',
     blocking: true,
   },
   signupUserAgreement: {
     v: 2,
+    label: 'User Agreement',
     text: 'By clicking Create Company Account, I acknowledge and accept the XtraFleet User Agreement.',
+    legalLink: '/legal/user-agreement',
     surface: 'signup',
     blocking: true,
   },
   signupEsignConsent: {
     v: 2,
+    label: 'E-Sign Consent',
     text: 'By clicking Create Company Account, I consent to use electronic records and signatures, as described in the E-Sign Consent.',
+    legalLink: '/legal/esign-consent',
     surface: 'signup',
     blocking: true,
   },
   signupTermsOfService: {
     v: 2,
+    label: 'Terms of Service',
     text: 'By clicking Create Company Account, I acknowledge and accept the Terms of Service.',
+    legalLink: '/legal/terms',
     surface: 'signup',
     blocking: true,
   },
   profileInsurance: {
     v: 1,
+    label: 'Insurance Coverage',
     text: 'We maintain required insurance coverage.',
     surface: 'profile',
     blocking: true,
   },
   profileAuthority: {
     v: 1,
+    label: 'DOT Authority',
     text: 'We operate under valid DOT authority.',
     surface: 'profile',
     blocking: true,
   },
   driverDqf: {
     v: 1,
+    label: 'Driver Qualification File',
     text: 'This driver is qualified under our Driver Qualification File (DQF).',
     surface: 'driver_add',
     blocking: true,
   },
   driverFmcsaChecks: {
     v: 1,
+    label: 'FMCSA Checks',
     text: 'We have conducted required checks under FMCSA regulations.',
     surface: 'driver_add',
     blocking: true,
   },
   driverAuthority: {
     v: 1,
+    label: 'Driver Authority',
     text: 'Driver is eligible to operate under our authority.',
     surface: 'driver_add',
     blocking: true,
   },
   matchBorrowerClearinghouse: {
     v: 1,
+    label: 'Clearinghouse Query',
     text: 'We have conducted or will conduct the required Clearinghouse full query if applicable.',
     surface: 'match_confirm_borrower',
     blocking: true,
   },
   matchBorrowerResponsibility: {
     v: 1,
+    label: 'Operational Responsibility',
     text: 'We accept responsibility for operating compliance during this trip.',
     surface: 'match_confirm_borrower',
     blocking: true,
   },
   matchBorrowerInsurance: {
     v: 1,
+    label: 'Insurance Applies to Trip',
     text: 'We confirm insurance coverage applies to this operation.',
     surface: 'match_confirm_borrower',
     blocking: true,
   },
   matchLenderQualified: {
     v: 1,
+    label: 'Driver Qualified',
     text: 'Driver remains qualified and in good standing.',
     surface: 'match_confirm_lender',
     blocking: true,
   },
   matchLenderAuthority: {
     v: 1,
+    label: 'Driver Authority',
     text: 'Driver is authorized to operate under the agreed authority structure.',
     surface: 'match_confirm_lender',
     blocking: true,
   },
   tlaEsignConsent: {
     v: 1,
+    label: 'Electronic Signature',
     text: 'I consent to use electronic signatures and understand my electronic signature is legally binding.',
+    legalLink: '/legal/esign-consent',
     surface: 'tla',
     blocking: true,
   },
   postTripCompleted: {
     v: 1,
+    label: 'Trip Completed',
     text: 'Trip was completed under agreed terms.',
     surface: 'post_trip',
     blocking: false,
   },
   postTripNoIncidents: {
     v: 1,
+    label: 'No Incidents',
     text: 'No compliance incidents occurred.',
     surface: 'post_trip',
     blocking: false,


### PR DESCRIPTION
## Summary
UX polish on the attestation flow and the admin pre-registration, in response to feedback that:
1. Attestations were rendered with their raw code keys (`profileInsurance`).
2. The recapture sheet showed boxes already checked.
3. There was no link to the legal text behind signup attestations.
4. Pre-registering a customer didn't send them the activation email.

## Changes
- **`src/lib/attestations.ts`** — `AttestationDef` gains a required `label` (e.g. "Insurance Coverage") and an optional `legalLink`. Labels populated for all 17 attestation types; legal links wired up for `signupUserAgreement`, `signupEsignConsent`, `signupTermsOfService`, and `tlaEsignConsent`.
- **`src/components/attestation-recapture-sheet.tsx`** — starts with **no boxes checked** (active opt-in), renders the label instead of the type key, and shows a "Read the full text" link when the attestation has a `legalLink`.
- **`src/app/dashboard/profile/page.tsx`** — the *Attestations on File* list now renders the human label.
- **`src/app/api/admin/onboard/route.ts`** — calls `sendActivationEmail` after pre-registering a customer so the customer gets the activation link directly. The admin still receives the link in the API response as a backup.

## Test Plan
- [ ] *Attestations on File* on the profile page shows "Insurance Coverage" / "DOT Authority" instead of `profileInsurance` / `profileAuthority`
- [ ] Opening the recapture sheet — no boxes are pre-checked
- [ ] Capture button stays disabled until at least one box is checked
- [ ] User Agreement / E-Sign Consent / Terms entries show a "Read the full text" link that opens the correct legal page
- [ ] Pre-registering via `/admin/onboard` — the customer receives the activation email at the contact email; admin also sees the link in the success card
- [ ] Existing accepted attestations still render correctly (no schema migration needed; the snapshot fields are unchanged)

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_