### PR TITLE
Admin: editability on /admin/users + send-activation (DEV-164 part 1)

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -45,7 +45,8 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useFirestore, useUser } from '@/firebase';
 import { collection, getDocs, doc, updateDoc, deleteDoc, setDoc, writeBatch } from 'firebase/firestore';
-import { Search, MoreHorizontal, Users, Truck, Package, Eye, RefreshCw, Building2, Ban, CheckCircle, Download, Loader2, UserPlus, Edit2, Trash2 } from 'lucide-react';
+import { Search, MoreHorizontal, Users, Truck, Package, Eye, RefreshCw, Building2, Ban, CheckCircle, Download, Loader2, UserPlus, Edit2, Trash2, Send } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import type { OwnerOperator } from '@/lib/data';
 import { logAuditAction } from '@/lib/audit';
 import { showSuccess, showError } from '@/lib/toast-utils';
@@ -61,14 +62,25 @@ type UserWithStats = OwnerOperator & {
 type EditableUserFields = {
   companyName: string;
   legalName: string;
+  contactName: string;
   contactEmail: string;
   phone: string;
   dotNumber: string;
   mcNumber: string;
+  ein: string;
+  dba: string;
   address: string;
+  hqAddress: string;
   city: string;
   state: string;
   zipCode: string;
+  loadLocation: string;
+  serviceRegions: string;
+  coiDocumentUrl: string;
+  coiDocumentUploadedAt: string;
+  accountStatus: '' | 'pre-activated' | 'active' | 'suspended';
+  subscriptionStatus: string;
+  subscriptionPlan: string;
 };
 
 export default function AdminUsersPage() {
@@ -91,28 +103,50 @@ export default function AdminUsersPage() {
   const [editForm, setEditForm] = useState<EditableUserFields>({
     companyName: '',
     legalName: '',
+    contactName: '',
     contactEmail: '',
     phone: '',
     dotNumber: '',
     mcNumber: '',
+    ein: '',
+    dba: '',
     address: '',
+    hqAddress: '',
     city: '',
     state: '',
     zipCode: '',
+    loadLocation: '',
+    serviceRegions: '',
+    coiDocumentUrl: '',
+    coiDocumentUploadedAt: '',
+    accountStatus: '',
+    subscriptionStatus: '',
+    subscriptionPlan: '',
   });
 
   // Create form state
   const [createForm, setCreateForm] = useState<EditableUserFields>({
     companyName: '',
     legalName: '',
+    contactName: '',
     contactEmail: '',
     phone: '',
     dotNumber: '',
     mcNumber: '',
+    ein: '',
+    dba: '',
     address: '',
+    hqAddress: '',
     city: '',
     state: '',
     zipCode: '',
+    loadLocation: '',
+    serviceRegions: '',
+    coiDocumentUrl: '',
+    coiDocumentUploadedAt: '',
+    accountStatus: '',
+    subscriptionStatus: '',
+    subscriptionPlan: '',
   });
 
   const canCreate = hasPermission('users:create');
@@ -207,14 +241,25 @@ export default function AdminUsersPage() {
       setCreateForm({
         companyName: '',
         legalName: '',
+        contactName: '',
         contactEmail: '',
         phone: '',
         dotNumber: '',
         mcNumber: '',
+        ein: '',
+        dba: '',
         address: '',
+        hqAddress: '',
         city: '',
         state: '',
         zipCode: '',
+        loadLocation: '',
+        serviceRegions: '',
+        coiDocumentUrl: '',
+        coiDocumentUploadedAt: '',
+        accountStatus: '',
+        subscriptionStatus: '',
+        subscriptionPlan: '',
       });
       fetchUsers();
     } catch (error: any) {
@@ -229,11 +274,20 @@ export default function AdminUsersPage() {
 
     setIsProcessing(true);
     try {
-      await updateDoc(doc(firestore, 'owner_operators', editingUser.id), {
-        ...editForm,
+      const { coiDocumentUrl, coiDocumentUploadedAt, accountStatus, ...rest } = editForm;
+      const payload: Record<string, any> = {
+        ...rest,
         updatedAt: new Date().toISOString(),
         updatedBy: adminUser.uid,
-      });
+      };
+      // Nested insurance fields via dot-notation so other insurance.* fields
+      // (set by other flows) aren't clobbered.
+      if (coiDocumentUrl) payload['insurance.coiDocumentUrl'] = coiDocumentUrl;
+      if (coiDocumentUploadedAt) payload['insurance.coiDocumentUploadedAt'] = coiDocumentUploadedAt;
+      // accountStatus is optional in the form — only flip when the admin picked a value.
+      if (accountStatus) payload.accountStatus = accountStatus;
+
+      await updateDoc(doc(firestore, 'owner_operators', editingUser.id), payload);
 
       await logAuditAction(firestore, {
         action: 'user_updated',
@@ -366,18 +420,60 @@ export default function AdminUsersPage() {
     }
   };
 
+  const handleSendActivation = async (user: UserWithStats) => {
+    if (!firestore || !adminUser) return;
+    if (user.accountStatus !== 'pre-activated') {
+      showError('Only pre-activated accounts can receive an activation email.');
+      return;
+    }
+    setIsProcessing(true);
+    try {
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(user.id)}/send-activation`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to send activation email.');
+      showSuccess(`Activation email sent to ${user.contactEmail}.`);
+      fetchUsers();
+    } catch (error: any) {
+      showError(error.message || 'Failed to send activation email.');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
   const handleOpenEdit = (user: UserWithStats) => {
+    const u = user as UserWithStats & {
+      address?: string;
+      city?: string;
+      state?: string;
+      zipCode?: string;
+      subscriptionStatus?: string;
+      subscriptionPlan?: string;
+    };
     setEditForm({
       companyName: user.companyName || '',
       legalName: user.legalName || '',
+      contactName: user.contactName || '',
       contactEmail: user.contactEmail || '',
       phone: user.phone || '',
       dotNumber: user.dotNumber || '',
       mcNumber: user.mcNumber || '',
-      address: (user as any).address || '',
-      city: (user as any).city || '',
-      state: (user as any).state || '',
-      zipCode: (user as any).zipCode || '',
+      ein: user.ein || '',
+      dba: user.dba || '',
+      address: u.address || '',
+      hqAddress: user.hqAddress || '',
+      city: u.city || '',
+      state: u.state || '',
+      zipCode: u.zipCode || '',
+      loadLocation: user.loadLocation || '',
+      serviceRegions: user.serviceRegions || '',
+      coiDocumentUrl: user.insurance?.coiDocumentUrl || '',
+      coiDocumentUploadedAt: user.insurance?.coiDocumentUploadedAt || '',
+      accountStatus: (user.accountStatus as '' | 'pre-activated' | 'active' | 'suspended') || '',
+      subscriptionStatus: u.subscriptionStatus || '',
+      subscriptionPlan: u.subscriptionPlan || '',
     });
     setEditingUser(user);
   };
@@ -529,6 +625,11 @@ export default function AdminUsersPage() {
                           {canEdit && (
                             <DropdownMenuItem onClick={() => handleOpenEdit(user)}>
                               <Edit2 className="h-4 w-4 mr-2" />Edit User
+                            </DropdownMenuItem>
+                          )}
+                          {user.accountStatus === 'pre-activated' && hasPermission('users:create') && (
+                            <DropdownMenuItem onClick={() => handleSendActivation(user)} className="text-blue-600">
+                              <Send className="h-4 w-4 mr-2" />Send Activation Email
                             </DropdownMenuItem>
                           )}
                           <DropdownMenuSeparator />
@@ -728,6 +829,75 @@ export default function AdminUsersPage() {
                 <div className="space-y-2">
                   <Label htmlFor="edit-zip">ZIP Code</Label>
                   <Input id="edit-zip" value={editForm.zipCode} onChange={(e) => setEditForm(f => ({ ...f, zipCode: e.target.value }))} />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-contact-name">Contact Name</Label>
+                <Input id="edit-contact-name" value={editForm.contactName} onChange={(e) => setEditForm(f => ({ ...f, contactName: e.target.value }))} />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="edit-ein">EIN</Label>
+                  <Input id="edit-ein" value={editForm.ein} onChange={(e) => setEditForm(f => ({ ...f, ein: e.target.value }))} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-dba">DBA</Label>
+                  <Input id="edit-dba" value={editForm.dba} onChange={(e) => setEditForm(f => ({ ...f, dba: e.target.value }))} />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-hq-address">HQ Address</Label>
+                <Input id="edit-hq-address" value={editForm.hqAddress} onChange={(e) => setEditForm(f => ({ ...f, hqAddress: e.target.value }))} />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="edit-load-location">Load Location</Label>
+                  <Input id="edit-load-location" value={editForm.loadLocation} onChange={(e) => setEditForm(f => ({ ...f, loadLocation: e.target.value }))} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-service-regions">Service Regions</Label>
+                  <Input id="edit-service-regions" value={editForm.serviceRegions} onChange={(e) => setEditForm(f => ({ ...f, serviceRegions: e.target.value }))} />
+                </div>
+              </div>
+              <div className="pt-4 border-t space-y-4">
+                <p className="text-sm font-medium text-muted-foreground">Account &amp; Subscription</p>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-account-status">Account Status</Label>
+                    <Select
+                      value={editForm.accountStatus || 'unchanged'}
+                      onValueChange={(v) => setEditForm(f => ({ ...f, accountStatus: v === 'unchanged' ? '' : (v as '' | 'pre-activated' | 'active' | 'suspended') }))}
+                    >
+                      <SelectTrigger id="edit-account-status">
+                        <SelectValue placeholder="Leave unchanged" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="unchanged">Leave unchanged</SelectItem>
+                        <SelectItem value="pre-activated">Pre-activated</SelectItem>
+                        <SelectItem value="active">Active</SelectItem>
+                        <SelectItem value="suspended">Suspended</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-subscription-status">Subscription Status</Label>
+                    <Input id="edit-subscription-status" value={editForm.subscriptionStatus} onChange={(e) => setEditForm(f => ({ ...f, subscriptionStatus: e.target.value }))} placeholder="e.g. active, inactive, trialing" />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-subscription-plan">Subscription Plan</Label>
+                  <Input id="edit-subscription-plan" value={editForm.subscriptionPlan} onChange={(e) => setEditForm(f => ({ ...f, subscriptionPlan: e.target.value }))} placeholder="e.g. starter, pro, enterprise" />
+                </div>
+              </div>
+              <div className="pt-4 border-t space-y-4">
+                <p className="text-sm font-medium text-muted-foreground">Insurance (COI)</p>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-coi-url">COI Document URL</Label>
+                  <Input id="edit-coi-url" type="url" value={editForm.coiDocumentUrl} onChange={(e) => setEditForm(f => ({ ...f, coiDocumentUrl: e.target.value }))} placeholder="https://..." />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-coi-uploaded">COI Uploaded At</Label>
+                  <Input id="edit-coi-uploaded" type="datetime-local" value={editForm.coiDocumentUploadedAt} onChange={(e) => setEditForm(f => ({ ...f, coiDocumentUploadedAt: e.target.value }))} />
                 </div>
               </div>
             </div>

--- a/src/app/api/admin/users/[id]/send-activation/route.ts
+++ b/src/app/api/admin/users/[id]/send-activation/route.ts
@@ -1,0 +1,172 @@
+/**
+ * Admin: (re)send activation email for a pre-activated account (DEV-164).
+ *
+ * Activation tokens are stored hashed — we can never reconstruct the raw
+ * token from Firestore. "Resend" therefore always **mints a fresh token**,
+ * marks any prior unconsumed tokens for this account as superseded, and
+ * emails the new link.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirebaseAdmin } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+import {
+  generateActivationToken,
+  hashActivationToken,
+  ACTIVATION_TOKEN_TTL_DAYS,
+} from '@/lib/activation-tokens';
+import { sendActivationEmail } from '@/lib/email';
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://xtrafleet.com';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+async function handlePost(
+  request: NextRequest,
+  context: { params: { id: string } }
+) {
+  try {
+    const ownerOperatorId = context.params.id;
+    if (!ownerOperatorId) {
+      return json({ error: 'A user id is required.' }, 400);
+    }
+
+    const { auth, db } = await getFirebaseAdmin();
+
+    // 1. Authenticate.
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+    const adminEmail = decoded.email || '';
+
+    // 2. Authorize — same permission as pre-registration.
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole =
+      (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'users:create')) {
+      return json({ error: 'You do not have permission to send activation links.' }, 403);
+    }
+
+    // 3. Load the target — must exist and still be pre-activated.
+    const ooRef = db.collection('owner_operators').doc(ownerOperatorId);
+    const ooSnap = await ooRef.get();
+    if (!ooSnap.exists) {
+      return json({ error: 'User not found.' }, 404);
+    }
+    const oo = ooSnap.data() as {
+      accountStatus?: string;
+      contactEmail?: string;
+      contactName?: string;
+      companyName?: string;
+    };
+    if (oo.accountStatus !== 'pre-activated') {
+      return json(
+        { error: 'This account is not pre-activated — no activation link is needed.' },
+        409
+      );
+    }
+    if (!oo.contactEmail) {
+      return json({ error: 'This account has no contact email on file.' }, 422);
+    }
+
+    const now = new Date().toISOString();
+
+    // 4. Invalidate any existing unconsumed tokens for this account, so the
+    //    previously-emailed link stops working.
+    const existing = await db
+      .collection('activation_tokens')
+      .where('ownerOperatorId', '==', ownerOperatorId)
+      .get();
+    const supersedeBatch = db.batch();
+    let supersededCount = 0;
+    for (const docSnap of existing.docs) {
+      const data = docSnap.data() as { consumedAt?: string };
+      if (data.consumedAt) continue;
+      supersedeBatch.update(docSnap.ref, { consumedAt: now, supersededBy: 'resend' });
+      supersededCount += 1;
+    }
+    if (supersededCount > 0) await supersedeBatch.commit();
+
+    // 5. Mint the new token.
+    const rawToken = generateActivationToken();
+    const expiresAt = new Date(
+      Date.now() + ACTIVATION_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000
+    ).toISOString();
+    await db
+      .collection('activation_tokens')
+      .doc(hashActivationToken(rawToken))
+      .set({
+        ownerOperatorId,
+        email: oo.contactEmail,
+        companyName: oo.companyName || '',
+        recipientName: oo.contactName || oo.companyName || '',
+        createdByAdmin: adminUid,
+        createdAt: now,
+        expiresAt,
+      });
+
+    const activationUrl = `${APP_URL}/activate?token=${rawToken}`;
+
+    // 6. Email it (best-effort — admin still gets the link in the response).
+    sendActivationEmail(
+      oo.contactEmail,
+      oo.contactName || oo.companyName || 'there',
+      activationUrl
+    ).catch((err) =>
+      console.error('[admin/users/send-activation] email failed', err)
+    );
+
+    // 7. Audit.
+    await db.collection('admin_audit').add({
+      action: 'user_activation_resent',
+      adminId: adminUid,
+      adminEmail,
+      targetType: 'user',
+      targetId: ownerOperatorId,
+      details: {
+        email: oo.contactEmail,
+        supersededTokens: supersededCount,
+      },
+      timestamp: now,
+    });
+
+    return json(
+      {
+        success: true,
+        activationUrl,
+        expiresAt,
+        supersededTokens: supersededCount,
+      },
+      200
+    );
+  } catch (error) {
+    console.error('[POST /api/admin/users/[id]/send-activation]', error);
+    return json(
+      { error: 'An unexpected error occurred while sending the activation email.' },
+      500
+    );
+  }
+}
+
+export const POST = withCors((req: NextRequest) => {
+  // withCors loses the dynamic-route params; pull them off the URL path.
+  const parts = req.nextUrl.pathname.split('/');
+  const id = parts[parts.length - 2]; // /api/admin/users/[id]/send-activation
+  return handlePost(req, { params: { id } });
+});

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,14 +1,25 @@
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { Firestore } from 'firebase/firestore';
 
-export type AuditAction = 
+export type AuditAction =
+  | 'user_created'
   | 'user_suspended'
   | 'user_reactivated'
   | 'user_updated'
-  | 'tla_voided'
-  | 'match_cancelled'
+  | 'user_deleted'
+  | 'user_activation_resent'
+  | 'driver_updated'
+  | 'driver_deleted'
   | 'driver_deactivated'
   | 'driver_reactivated'
+  | 'load_updated'
+  | 'load_deleted'
+  | 'match_cancelled'
+  | 'match_updated'
+  | 'match_deleted'
+  | 'tla_voided'
+  | 'tla_updated'
+  | 'tla_deleted'
   | 'admin_login'
   | 'data_exported';
 
@@ -17,7 +28,7 @@ export interface AuditLogEntry {
   action: AuditAction;
   adminId: string;
   adminEmail: string;
-  targetType: 'user' | 'tla' | 'match' | 'driver' | 'system';
+  targetType: 'user' | 'tla' | 'match' | 'driver' | 'load' | 'system';
   targetId: string;
   targetName?: string;
   details?: Record<string, any>;
@@ -41,13 +52,24 @@ export async function logAuditAction(
 
 export function getActionLabel(action: AuditAction): string {
   const labels: Record<AuditAction, string> = {
+    user_created: 'User Created',
     user_suspended: 'User Suspended',
     user_reactivated: 'User Reactivated',
     user_updated: 'User Updated',
-    tla_voided: 'TLA Voided',
-    match_cancelled: 'Match Cancelled',
+    user_deleted: 'User Deleted',
+    user_activation_resent: 'Activation Email Sent',
+    driver_updated: 'Driver Updated',
+    driver_deleted: 'Driver Deleted',
     driver_deactivated: 'Driver Deactivated',
     driver_reactivated: 'Driver Reactivated',
+    load_updated: 'Load Updated',
+    load_deleted: 'Load Deleted',
+    match_cancelled: 'Match Cancelled',
+    match_updated: 'Match Updated',
+    match_deleted: 'Match Deleted',
+    tla_voided: 'TLA Voided',
+    tla_updated: 'TLA Updated',
+    tla_deleted: 'TLA Deleted',
     admin_login: 'Admin Login',
     data_exported: 'Data Exported',
   };
@@ -58,8 +80,11 @@ export function getActionColor(action: AuditAction): string {
   if (action.includes('suspended') || action.includes('voided') || action.includes('cancelled') || action.includes('deactivated')) {
     return 'text-red-600';
   }
-  if (action.includes('reactivated')) {
+  if (action.includes('reactivated') || action.includes('activation_resent')) {
     return 'text-green-600';
+  }
+  if (action.includes('updated')) {
+    return 'text-amber-600';
   }
   return 'text-blue-600';
 }


### PR DESCRIPTION
First chunk of **DEV-164** (admin console editability). Foundation + the highest-impact page (`/admin/users`).

## What's in this PR

### Foundation
- **`src/lib/audit.ts`** — extends `AuditAction` with the actions used across all admin pages today (some pre-existing TS errors) plus the new actions DEV-164 needs (`user_activation_resent`, `load_updated`, `match_updated`, `tla_updated`); adds `'load'` to `targetType`.
- **`POST /api/admin/users/[id]/send-activation`** — admin-gated (`users:create`). Activation tokens are hashed-only, so "resend" always mints a fresh token, invalidates any prior unconsumed ones for the account, and emails the new link. Audit-logged.

### `/admin/users`
- Edit dialog now covers every persisted OwnerOperator field that wasn't editable: `contactName`, `ein`, `dba`, `hqAddress`, `loadLocation`, `serviceRegions`, `insurance.coiDocumentUrl`, `insurance.coiDocumentUploadedAt`, `accountStatus`, `subscriptionStatus`, `subscriptionPlan`.
- `accountStatus` uses a "Leave unchanged" select so flips between `pre-activated` / `active` / `suspended` are explicit (not accidentally cleared).
- Nested `insurance.*` written via dot-notation so other `insurance.*` fields aren't clobbered.
- New row action: **Send Activation Email** for pre-activated accounts only, gated on `users:create`.

## Test plan
- [ ] Open an existing user — every previously-editable field still saves
- [ ] Edit `ein`, `dba`, `hqAddress`, etc. — values persist
- [ ] Edit `insurance.coiDocumentUrl` — only that nested field changes
- [ ] Set `accountStatus` to *Leave unchanged* — the doc's existing status is preserved
- [ ] Flip a pre-activated account to active — status badge / behavior updates
- [ ] Click *Send Activation Email* on a pre-activated user — they get a new link; old link no longer works
- [ ] Audit log shows `user_updated` and `user_activation_resent` entries

## Follow-ups (separate PRs for the same ticket)
- `/admin/drivers` — extend edit dialog with the missing compliance fields
- `/admin/loads` — wire `loads:edit` + build the edit dialog
- `/admin/matches` — edit terms
- `/admin/tlas` — edit payment / insurance / trip-tracking fields

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_