### PR TITLE
fix(admin/drivers): Edit Driver crashed on Vehicle Type Select

### DIFF
--- a/src/app/admin/drivers/page.tsx
+++ b/src/app/admin/drivers/page.tsx
@@ -663,7 +663,7 @@ export default function AdminDriversPage() {
                     <SelectTrigger><SelectValue placeholder="Select type" /></SelectTrigger>
                     <SelectContent>
                       {TRAILER_TYPES.map(type => (
-                        <SelectItem key={type} value={type}>{type}</SelectItem>
+                        <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>


### PR DESCRIPTION
## Bug
Opening **Edit Driver** in `/admin/drivers` crashed the page with React error #31 ("Objects are not valid as a React child").

## Cause
`TRAILER_TYPES` is `{value, label, description}[]`. The pre-existing Vehicle Type Select rendered `type` (the whole object) as the SelectItem's `key`, `value`, and child:

```tsx
{TRAILER_TYPES.map(type => (
  <SelectItem key={type} value={type}>{type}</SelectItem>  // ❌
))}
```

Latent pre-existing bug — the 3 TS errors at this site have lived in the repo since `trailer-types` shipped, masked by `ignoreBuildErrors: true`. My DEV-164 edits made the dialog larger / easier to reach, surfacing the crash.

## Fix
Use `type.value` / `type.label`:

```tsx
{TRAILER_TYPES.map(type => (
  <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>  // ✅
))}
```

## Test
- [ ] `/admin/drivers` → click a driver → **Edit Driver** opens without crashing
- [ ] Vehicle Type dropdown shows readable labels (e.g. "Dry Van", "Reefer (Refrigerated)")
- [ ] Saving still writes the value (`dry-van`, etc.)

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_