### PR TITLE
Admin: unify on 3-dot menu pattern across /admin tables (DEV-164 follow-up)

### DIFF
--- a/src/app/admin/loads/page.tsx
+++ b/src/app/admin/loads/page.tsx
@@ -30,6 +30,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -45,7 +52,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useFirestore, useUser } from '@/firebase';
 import { collectionGroup, getDocs, doc, getDoc, deleteDoc, updateDoc } from 'firebase/firestore';
-import { Search, Package, RefreshCw, ArrowRight, Building2, Download, Trash2, Loader2, Edit2 } from 'lucide-react';
+import { Search, Package, RefreshCw, ArrowRight, Building2, Download, Trash2, Loader2, Edit2, MoreHorizontal, Eye } from 'lucide-react';
 import { showSuccess, showError } from '@/lib/toast-utils';
 import { useAdminRole } from '../layout';
 import { format, formatDistanceToNow } from 'date-fns';
@@ -419,12 +426,13 @@ export default function AdminLoadsPage() {
                 <TableHead>Status</TableHead>
                 <TableHead>Owner</TableHead>
                 <TableHead>Created</TableHead>
+                <TableHead className="w-12"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? <TableSkeleton /> : filteredLoads.length > 0 ? (
                 filteredLoads.map(load => (
-                  <TableRow key={load.id} className="cursor-pointer hover:bg-muted/50">
+                  <TableRow key={load.id} className="hover:bg-muted/50">
                     {canDelete && (
                       <TableCell onClick={(e) => e.stopPropagation()}>
                         <Checkbox
@@ -434,24 +442,42 @@ export default function AdminLoadsPage() {
                         />
                       </TableCell>
                     )}
-                    <TableCell className="font-medium" onClick={() => setSelectedLoad(load)}>
+                    <TableCell className="font-medium">
                       <div className="flex items-center gap-1">{load.origin}<ArrowRight className="h-3 w-3 text-muted-foreground" />{load.destination}</div>
                     </TableCell>
-                    <TableCell onClick={() => setSelectedLoad(load)}>{load.cargo || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedLoad(load)}>{load.weight?.toLocaleString() || '-'} lbs</TableCell>
-                    <TableCell onClick={() => setSelectedLoad(load)} className="text-green-600 font-medium">${load.price?.toLocaleString() || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedLoad(load)}><Badge variant={getStatusBadgeVariant(load.status)}>{load.status || 'Unknown'}</Badge></TableCell>
-                    <TableCell onClick={() => setSelectedLoad(load)}>
+                    <TableCell>{load.cargo || '-'}</TableCell>
+                    <TableCell>{load.weight?.toLocaleString() || '-'} lbs</TableCell>
+                    <TableCell className="text-green-600 font-medium">${load.price?.toLocaleString() || '-'}</TableCell>
+                    <TableCell><Badge variant={getStatusBadgeVariant(load.status)}>{load.status || 'Unknown'}</Badge></TableCell>
+                    <TableCell>
                       <div className="flex items-center gap-1 text-sm text-muted-foreground">
                         <Building2 className="h-3 w-3" />{load.ownerCompanyName || 'Unknown'}
                       </div>
                     </TableCell>
-                    <TableCell onClick={() => setSelectedLoad(load)} className="text-muted-foreground text-sm">{load.createdAt ? formatDistanceToNow(new Date(load.createdAt), { addSuffix: true }) : '-'}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{load.createdAt ? formatDistanceToNow(new Date(load.createdAt), { addSuffix: true }) : '-'}</TableCell>
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon"><MoreHorizontal className="h-4 w-4" /></Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                          <DropdownMenuItem onClick={() => setSelectedLoad(load)}>
+                            <Eye className="h-4 w-4 mr-2" />View Details
+                          </DropdownMenuItem>
+                          {canEdit && (
+                            <DropdownMenuItem onClick={() => handleOpenEditLoad(load)}>
+                              <Edit2 className="h-4 w-4 mr-2" />Edit Load
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
                   </TableRow>
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={canDelete ? 8 : 7} className="h-24 text-center">
+                  <TableCell colSpan={canDelete ? 9 : 8} className="h-24 text-center">
                     <Package className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
                     <p className="text-muted-foreground">No loads found</p>
                   </TableCell>
@@ -494,13 +520,6 @@ export default function AdminLoadsPage() {
                 </div>
               )}
             </div>
-          )}
-          {canEdit && selectedLoad && (
-            <DialogFooter>
-              <Button variant="outline" onClick={() => handleOpenEditLoad(selectedLoad)}>
-                <Edit2 className="h-4 w-4 mr-2" />Edit Load
-              </Button>
-            </DialogFooter>
           )}
         </DialogContent>
       </Dialog>

--- a/src/app/admin/matches/page.tsx
+++ b/src/app/admin/matches/page.tsx
@@ -45,7 +45,15 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useFirestore, useUser } from '@/firebase';
 import { collection, getDocs, doc, updateDoc, getDoc, deleteDoc } from 'firebase/firestore';
-import { Search, Link2, RefreshCw, ArrowRight, Ban, Download, Loader2, Trash2, Edit2 } from 'lucide-react';
+import { Search, Link2, RefreshCw, ArrowRight, Ban, Download, Loader2, Trash2, Edit2, MoreHorizontal, Eye } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useAdminRole } from '../layout';
 import { format, formatDistanceToNow } from 'date-fns';
 import type { Match, MatchStatus } from '@/lib/data';
@@ -456,12 +464,13 @@ export default function AdminMatchesPage() {
                 <TableHead>Status</TableHead>
                 <TableHead>Score</TableHead>
                 <TableHead>Created</TableHead>
+                <TableHead className="w-12"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? <TableSkeleton /> : filteredMatches.length > 0 ? (
                 filteredMatches.map(match => (
-                  <TableRow key={match.id} className="cursor-pointer hover:bg-muted/50">
+                  <TableRow key={match.id} className="hover:bg-muted/50">
                     {canDelete && (
                       <TableCell onClick={(e) => e.stopPropagation()}>
                         <Checkbox
@@ -471,19 +480,45 @@ export default function AdminMatchesPage() {
                         />
                       </TableCell>
                     )}
-                    <TableCell className="font-medium" onClick={() => setSelectedMatch(match)}>
+                    <TableCell className="font-medium">
                       <div className="flex items-center gap-1">{match.loadSnapshot?.origin}<ArrowRight className="h-3 w-3 text-muted-foreground" />{match.loadSnapshot?.destination}</div>
                     </TableCell>
-                    <TableCell onClick={() => setSelectedMatch(match)}>{match.driverSnapshot?.name || match.driverName || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedMatch(match)}>{match.loadOwnerName || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedMatch(match)}><Badge variant={getStatusBadgeVariant(match.status)}>{match.status.replace('_', ' ')}</Badge></TableCell>
-                    <TableCell onClick={() => setSelectedMatch(match)}>{match.matchScore}/100</TableCell>
-                    <TableCell onClick={() => setSelectedMatch(match)} className="text-muted-foreground text-sm">{match.createdAt ? formatDistanceToNow(new Date(match.createdAt), { addSuffix: true }) : '-'}</TableCell>
+                    <TableCell>{match.driverSnapshot?.name || match.driverName || '-'}</TableCell>
+                    <TableCell>{match.loadOwnerName || '-'}</TableCell>
+                    <TableCell><Badge variant={getStatusBadgeVariant(match.status)}>{match.status.replace('_', ' ')}</Badge></TableCell>
+                    <TableCell>{match.matchScore}/100</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{match.createdAt ? formatDistanceToNow(new Date(match.createdAt), { addSuffix: true }) : '-'}</TableCell>
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon"><MoreHorizontal className="h-4 w-4" /></Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                          <DropdownMenuItem onClick={() => setSelectedMatch(match)}>
+                            <Eye className="h-4 w-4 mr-2" />View Details
+                          </DropdownMenuItem>
+                          {canEditMatch && (
+                            <DropdownMenuItem onClick={() => handleOpenEditMatch(match)}>
+                              <Edit2 className="h-4 w-4 mr-2" />Edit
+                            </DropdownMenuItem>
+                          )}
+                          {canCancelMatch(match) && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem onClick={() => setCancellingMatch(match)} className="text-destructive">
+                                <Ban className="h-4 w-4 mr-2" />Cancel Match
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
                   </TableRow>
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={canDelete ? 7 : 6} className="h-24 text-center">
+                  <TableCell colSpan={canDelete ? 8 : 7} className="h-24 text-center">
                     <Link2 className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
                     <p className="text-muted-foreground">No matches found</p>
                   </TableCell>
@@ -508,18 +543,7 @@ export default function AdminMatchesPage() {
                   <Badge variant={getStatusBadgeVariant(selectedMatch.status)}>{selectedMatch.status.replace('_', ' ')}</Badge>
                   <span className="text-sm text-muted-foreground">Score: {selectedMatch.matchScore}/100</span>
                 </div>
-                <div className="flex gap-2">
-                  {canEditMatch && (
-                    <Button variant="outline" size="sm" onClick={() => handleOpenEditMatch(selectedMatch)}>
-                      <Edit2 className="h-4 w-4 mr-2" />Edit
-                    </Button>
-                  )}
-                  {canCancelMatch(selectedMatch) && (
-                    <Button variant="destructive" size="sm" onClick={() => setCancellingMatch(selectedMatch)}>
-                      <Ban className="h-4 w-4 mr-2" />Cancel Match
-                    </Button>
-                  )}
-                </div>
+                <div />
               </div>
               
               <div className="grid grid-cols-2 gap-4">

--- a/src/app/admin/tlas/page.tsx
+++ b/src/app/admin/tlas/page.tsx
@@ -44,8 +44,16 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useFirestore, useUser } from '@/firebase';
 import { collection, getDocs, doc, updateDoc, deleteDoc } from 'firebase/firestore';
-import { Search, FileText, RefreshCw, ArrowRight, CheckCircle, XCircle, Ban, Download, Loader2, Trash2, Edit2 } from 'lucide-react';
+import { Search, FileText, RefreshCw, ArrowRight, CheckCircle, XCircle, Ban, Download, Loader2, Trash2, Edit2, MoreHorizontal, Eye } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useAdminRole } from '../layout';
 import { format, formatDistanceToNow } from 'date-fns';
 import type { TLA } from '@/lib/data';
@@ -454,12 +462,13 @@ export default function AdminTLAsPage() {
                 <TableHead>Status</TableHead>
                 <TableHead>Amount</TableHead>
                 <TableHead>Created</TableHead>
+                <TableHead className="w-12"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? <TableSkeleton /> : filteredTLAs.length > 0 ? (
                 filteredTLAs.map(tla => (
-                  <TableRow key={tla.id} className="cursor-pointer hover:bg-muted/50">
+                  <TableRow key={tla.id} className="hover:bg-muted/50">
                     {canDelete && (
                       <TableCell onClick={(e) => e.stopPropagation()}>
                         <Checkbox
@@ -469,20 +478,46 @@ export default function AdminTLAsPage() {
                         />
                       </TableCell>
                     )}
-                    <TableCell className="font-medium" onClick={() => setSelectedTLA(tla)}>
+                    <TableCell className="font-medium">
                       <div className="flex items-center gap-1">{tla.trip?.origin}<ArrowRight className="h-3 w-3 text-muted-foreground" />{tla.trip?.destination}</div>
                     </TableCell>
-                    <TableCell onClick={() => setSelectedTLA(tla)}>{tla.driver?.name || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedTLA(tla)}>{tla.lessor?.legalName || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedTLA(tla)}>{tla.lessee?.legalName || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedTLA(tla)}><Badge variant={getStatusBadgeVariant(tla.status)}>{tla.status.replace('_', ' ')}</Badge></TableCell>
-                    <TableCell onClick={() => setSelectedTLA(tla)}>${tla.payment?.amount?.toLocaleString() || '-'}</TableCell>
-                    <TableCell onClick={() => setSelectedTLA(tla)} className="text-muted-foreground text-sm">{tla.createdAt ? formatDistanceToNow(new Date(tla.createdAt), { addSuffix: true }) : '-'}</TableCell>
+                    <TableCell>{tla.driver?.name || '-'}</TableCell>
+                    <TableCell>{tla.lessor?.legalName || '-'}</TableCell>
+                    <TableCell>{tla.lessee?.legalName || '-'}</TableCell>
+                    <TableCell><Badge variant={getStatusBadgeVariant(tla.status)}>{tla.status.replace('_', ' ')}</Badge></TableCell>
+                    <TableCell>${tla.payment?.amount?.toLocaleString() || '-'}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{tla.createdAt ? formatDistanceToNow(new Date(tla.createdAt), { addSuffix: true }) : '-'}</TableCell>
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon"><MoreHorizontal className="h-4 w-4" /></Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                          <DropdownMenuItem onClick={() => setSelectedTLA(tla)}>
+                            <Eye className="h-4 w-4 mr-2" />View Details
+                          </DropdownMenuItem>
+                          {canEditTLA && (
+                            <DropdownMenuItem onClick={() => handleOpenEditTLA(tla)}>
+                              <Edit2 className="h-4 w-4 mr-2" />Edit
+                            </DropdownMenuItem>
+                          )}
+                          {canVoidTLA(tla) && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem onClick={() => setVoidingTLA(tla)} className="text-destructive">
+                                <Ban className="h-4 w-4 mr-2" />Void TLA
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
                   </TableRow>
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={canDelete ? 8 : 7} className="h-24 text-center">
+                  <TableCell colSpan={canDelete ? 9 : 8} className="h-24 text-center">
                     <FileText className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
                     <p className="text-muted-foreground">No TLAs found</p>
                   </TableCell>
@@ -507,18 +542,7 @@ export default function AdminTLAsPage() {
                   <Badge variant={getStatusBadgeVariant(selectedTLA.status)}>{selectedTLA.status.replace('_', ' ')}</Badge>
                   <span className="text-sm text-muted-foreground">Version {selectedTLA.version}</span>
                 </div>
-                <div className="flex gap-2">
-                  {canEditTLA && (
-                    <Button variant="outline" size="sm" onClick={() => handleOpenEditTLA(selectedTLA)}>
-                      <Edit2 className="h-4 w-4 mr-2" />Edit
-                    </Button>
-                  )}
-                  {canVoidTLA(selectedTLA) && (
-                    <Button variant="destructive" size="sm" onClick={() => setVoidingTLA(selectedTLA)}>
-                      <Ban className="h-4 w-4 mr-2" />Void TLA
-                    </Button>
-                  )}
-                </div>
+                <div />
               </div>
 
               <div className="grid grid-cols-2 gap-6">


### PR DESCRIPTION
## Why
QA testing flagged that `/admin/users` and `/admin/drivers` use a 3-dot row menu, while `/admin/loads`, `/admin/matches`, and `/admin/tlas` use row-click → dialog with action buttons inside. Pattern inconsistency. Standardizing on the 3-dot menu (it's the SaaS norm — Stripe, Linear, Notion, HubSpot all do this — and 2 of 5 pages already used it).

## Changes
On `/admin/loads`, `/admin/matches`, and `/admin/tlas`:
- New **Actions** column at the end of each table with a `DropdownMenu` (View Details + Edit + cancel/void where applicable).
- Row click no longer opens the view dialog — you now open it from the menu's **View Details** item, matching users/drivers.
- Action buttons removed from inside the view dialogs (they were duplicative once moved into the menu).

Per page:
- **`/admin/loads`** — View Details, Edit Load (`loads:edit`)
- **`/admin/matches`** — View Details, Edit (`matches:cancel`), Cancel Match (`canCancelMatch`)
- **`/admin/tlas`** — View Details, Edit (`tlas:void`), Void TLA (`canVoidTLA`)

## Test plan
- [ ] Each of the 5 admin tables shows a 3-dot icon at the end of each row
- [ ] Clicking the 3-dot opens an Actions menu (does not open the view dialog)
- [ ] Clicking the row body does not open anything
- [ ] *View Details* opens the dialog; the dialog has no action buttons
- [ ] Edit / Cancel / Void all still work from the menu items
- [ ] Bulk-delete (checkbox + button) still works unchanged

## Not in this PR
Per-row delete on loads/matches/tlas (they currently only have bulk delete via the checkbox). Adding per-row delete to the menu would match users/drivers fully — happy to do that as a small follow-up if you want it.

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_