### PR TITLE
Admin: refund action on /admin/tlas + harden refund endpoint (DEV-165 part 1)

### DIFF
--- a/src/app/admin/tlas/page.tsx
+++ b/src/app/admin/tlas/page.tsx
@@ -43,8 +43,9 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useFirestore, useUser } from '@/firebase';
-import { collection, getDocs, doc, updateDoc, deleteDoc } from 'firebase/firestore';
-import { Search, FileText, RefreshCw, ArrowRight, CheckCircle, XCircle, Ban, Download, Loader2, Trash2, Edit2, MoreHorizontal, Eye } from 'lucide-react';
+import { collection, getDocs, doc, updateDoc, deleteDoc, query, where, getDoc, limit } from 'firebase/firestore';
+import { Search, FileText, RefreshCw, ArrowRight, CheckCircle, XCircle, Ban, Download, Loader2, Trash2, Edit2, MoreHorizontal, Eye, DollarSign } from 'lucide-react';
+import { RefundModal } from '@/components/admin/billing/refund-modal';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   DropdownMenu,
@@ -122,6 +123,55 @@ export default function AdminTLAsPage() {
 
   const canDelete = hasPermission('tlas:delete');
   const canEditTLA = hasPermission('tlas:void');
+  const canRefund = hasPermission('billing:refund');
+
+  const [refundPayment, setRefundPayment] = useState<any | null>(null);
+  const [refundOwnerOp, setRefundOwnerOp] = useState<any | null>(null);
+  const [isLookingUpRefund, setIsLookingUpRefund] = useState(false);
+
+  const handleOpenRefund = async (tla: TLA) => {
+    if (!firestore) return;
+    if (!tla.matchId) {
+      showError('This TLA has no match — no payment to refund.');
+      return;
+    }
+    setIsLookingUpRefund(true);
+    try {
+      // Find a refundable payment for this match (succeeded, not yet refunded).
+      const paymentsQuery = query(
+        collection(firestore, 'payments'),
+        where('matchId', '==', tla.matchId),
+        where('status', '==', 'succeeded'),
+        limit(1)
+      );
+      const snap = await getDocs(paymentsQuery);
+      if (snap.empty) {
+        showError('No refundable payment found for this match.');
+        return;
+      }
+      const paymentDoc = snap.docs[0];
+      const payment = { id: paymentDoc.id, ...paymentDoc.data() } as any;
+
+      // Load the OwnerOperator that paid (the refund returns to them).
+      const ooSnap = await getDoc(doc(firestore, 'owner_operators', payment.ownerOperatorId));
+      if (!ooSnap.exists()) {
+        showError('Payment owner not found.');
+        return;
+      }
+      const ooData = ooSnap.data() as any;
+      setRefundOwnerOp({
+        id: ooSnap.id,
+        email: ooData?.contactEmail || '',
+        companyName: ooData?.companyName || ooData?.legalName || '',
+      });
+      setRefundPayment(payment);
+    } catch (e: any) {
+      console.error('[Refund lookup]', e);
+      showError('Failed to load refund details.');
+    } finally {
+      setIsLookingUpRefund(false);
+    }
+  };
 
   const fetchTLAs = async () => {
     if (!firestore) return;
@@ -502,6 +552,11 @@ export default function AdminTLAsPage() {
                               <Edit2 className="h-4 w-4 mr-2" />Edit
                             </DropdownMenuItem>
                           )}
+                          {canRefund && tla.matchId && (
+                            <DropdownMenuItem onClick={() => handleOpenRefund(tla)} disabled={isLookingUpRefund}>
+                              <DollarSign className="h-4 w-4 mr-2" />Process Refund
+                            </DropdownMenuItem>
+                          )}
                           {canVoidTLA(tla) && (
                             <>
                               <DropdownMenuSeparator />
@@ -739,6 +794,26 @@ export default function AdminTLAsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Refund Modal */}
+      {refundPayment && refundOwnerOp && (
+        <RefundModal
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              setRefundPayment(null);
+              setRefundOwnerOp(null);
+            }
+          }}
+          payment={refundPayment}
+          ownerOperator={refundOwnerOp}
+          onRefundComplete={() => {
+            setRefundPayment(null);
+            setRefundOwnerOp(null);
+            fetchTLAs();
+          }}
+        />
+      )}
 
       {/* Void TLA Dialog */}
       <AlertDialog open={!!voidingTLA} onOpenChange={(open) => { if (!open) { setVoidingTLA(null); setVoidReason(''); } }}>

--- a/src/app/api/stripe/refund/route.ts
+++ b/src/app/api/stripe/refund/route.ts
@@ -1,52 +1,95 @@
+/**
+ * Admin: process a Stripe refund.
+ *
+ * Authenticates the caller, requires `billing:refund`, calls the Stripe
+ * Refunds API, flips the Payment doc to `refunded`, and writes an audit-log
+ * entry with the real admin id (used to be hardcoded as 'admin').
+ *
+ * The previous implementation imported `adminDb` from `@/lib/firebase-admin`,
+ * which only exports `getAdminDb()` — so this endpoint had never actually
+ * worked (any call would crash on the first Firestore read). Fixed to use
+ * the singleton + admin auth properly.
+ */
 import { NextRequest, NextResponse } from 'next/server';
-import { FieldValue } from 'firebase-admin/firestore';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: NextRequest) {
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+async function handlePost(request: NextRequest) {
   try {
-    // Dynamic imports to prevent build-time initialization
-    const Stripe = (await import('stripe')).default;
-    const { adminDb } = await import('@/lib/firebase-admin');
-    
     if (!process.env.STRIPE_SECRET_KEY) {
-      throw new Error('STRIPE_SECRET_KEY is not set');
+      return json({ error: 'Stripe is not configured.' }, 503);
     }
-    
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2024-12-18.acacia',
-    });
-    
-    const { paymentId, reason, details, ownerOperatorId } = await request.json();
 
+    const { auth, db } = await getFirebaseAdmin();
+
+    // 1. Authenticate.
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+    const adminEmail = decoded.email || '';
+
+    // 2. Authorize.
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'billing:refund')) {
+      return json({ error: 'You do not have permission to process refunds.' }, 403);
+    }
+
+    // 3. Validate input.
+    let body: { paymentId?: string; reason?: string; details?: string; ownerOperatorId?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: 'Invalid request body.' }, 400);
+    }
+    const { paymentId, reason, details, ownerOperatorId } = body;
     if (!paymentId || !reason || !details || !ownerOperatorId) {
-      return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 }
-      );
+      return json({ error: 'Missing required fields' }, 400);
     }
 
-    // Fetch the payment from Firestore
-    const paymentDoc = await adminDb.collection('payments').doc(paymentId).get();
-
+    // 4. Load the payment.
+    const paymentDoc = await db.collection('payments').doc(paymentId).get();
     if (!paymentDoc.exists) {
-      return NextResponse.json(
-        { error: 'Payment not found' },
-        { status: 404 }
-      );
+      return json({ error: 'Payment not found' }, 404);
     }
-
-    const paymentData = paymentDoc.data();
-
+    const paymentData = paymentDoc.data() as
+      | { stripePaymentIntentId?: string; status?: string; amount?: number; matchId?: string; loadId?: string }
+      | undefined;
     if (!paymentData?.stripePaymentIntentId) {
-      return NextResponse.json(
-        { error: 'No Stripe payment intent found for this payment' },
-        { status: 400 }
-      );
+      return json({ error: 'No Stripe payment intent on this payment' }, 400);
+    }
+    if (paymentData.status === 'refunded') {
+      return json({ error: 'This payment has already been refunded.' }, 409);
     }
 
-    // Create refund in Stripe
+    // 5. Process the refund.
+    const Stripe = (await import('stripe')).default;
+    // Use the SDK's default API version (avoids a TS apiVersion-mismatch error
+    // and lets the installed SDK pick a compatible version for refunds).
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
     const refund = await stripe.refunds.create({
       payment_intent: paymentData.stripePaymentIntentId,
       reason: 'requested_by_customer',
@@ -55,45 +98,47 @@ export async function POST(request: NextRequest) {
         refund_details: details,
         owner_operator_id: ownerOperatorId,
         admin_refund: 'true',
+        admin_id: adminUid,
       },
     });
 
-    // Update payment status in Firestore
-    await adminDb.collection('payments').doc(paymentId).update({
+    // 6. Mark the payment refunded.
+    await db.collection('payments').doc(paymentId).update({
       status: 'refunded',
       refundedAt: FieldValue.serverTimestamp(),
       refundReason: reason,
       refundDetails: details,
+      refundedBy: adminUid,
       stripeRefundId: refund.id,
       updatedAt: FieldValue.serverTimestamp(),
     });
 
-    // Create audit log entry
-    await adminDb.collection('audit_logs').add({
-      action: 'refund_processed',
-      entityType: 'payment',
-      entityId: paymentId,
-      performedBy: 'admin', // TODO: Get actual admin user ID from session
-      ownerOperatorId,
-      metadata: {
+    // 7. Audit log — real admin id, not the previously-hardcoded 'admin'.
+    await db.collection('audit_logs').add({
+      action: 'billing_refunded',
+      adminId: adminUid,
+      adminEmail,
+      targetType: 'system',
+      targetId: paymentId,
+      targetName: `Payment ${paymentId}`,
+      reason,
+      details: {
         amount: paymentData.amount,
-        reason,
-        details,
+        refundDetails: details,
         stripeRefundId: refund.id,
+        ownerOperatorId,
+        matchId: paymentData.matchId,
+        loadId: paymentData.loadId,
       },
       timestamp: FieldValue.serverTimestamp(),
+      createdAt: new Date().toISOString(),
     });
 
-    return NextResponse.json({
-      success: true,
-      refundId: refund.id,
-      amount: refund.amount,
-    });
-  } catch (error) {
-    console.error('Error processing refund:', error);
-    return NextResponse.json(
-      { error: 'Failed to process refund' },
-      { status: 500 }
-    );
+    return json({ success: true, refundId: refund.id, amount: refund.amount }, 200);
+  } catch (error: any) {
+    console.error('[POST /api/stripe/refund]', error);
+    return json({ error: error?.message || 'Failed to process refund' }, 500);
   }
 }
+
+export const POST = withCors(handlePost);

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -20,6 +20,7 @@ export type AuditAction =
   | 'tla_voided'
   | 'tla_updated'
   | 'tla_deleted'
+  | 'billing_refunded'
   | 'admin_login'
   | 'data_exported';
 
@@ -70,6 +71,7 @@ export function getActionLabel(action: AuditAction): string {
     tla_voided: 'TLA Voided',
     tla_updated: 'TLA Updated',
     tla_deleted: 'TLA Deleted',
+    billing_refunded: 'Payment Refunded',
     admin_login: 'Admin Login',
     data_exported: 'Data Exported',
   };


### PR DESCRIPTION
First chunk of **DEV-165** (operational levers). Surfaces the existing `/api/stripe/refund` endpoint as an action on the TLA 3-dot menu, and fixes two real bugs in the endpoint itself along the way.

## Endpoint hardening

The audit flagged "refunds aren't exposed in the UI." It turned out the endpoint was also fundamentally broken:

- Was destructuring `{ adminDb }` from `@/lib/firebase-admin` — but that module only exports `getAdminDb()`. `adminDb` was always `undefined`, so the endpoint would crash on the first Firestore read. Switched to the singleton.
- **No authentication or permission check** — any unauthenticated caller could have triggered a refund on any payment ID they could guess. Added admin auth + `billing:refund` permission check.
- Audit log's `performedBy` was hardcoded as the string `'admin'`. Now uses the real admin uid + email.
- Now rejects refunding an already-refunded payment with 409.
- Removed the explicit Stripe `apiVersion` to avoid a TS mismatch with the installed SDK.

## UI on `/admin/tlas`

- New **Process Refund** item in the TLA 3-dot menu, gated on `billing:refund` and only shown when the TLA has a `matchId`.
- Finds a refundable payment (`status === 'succeeded'` and `matchId === tla.matchId`), fetches the paying OwnerOperator, and opens the existing `RefundModal` component (the same one `/admin/billing` uses — no UI duplication).
- Audit-logged as `billing_refunded`.

## Test plan
- [ ] As a super-admin, open a TLA whose match has a `succeeded` payment → 3-dot → **Process Refund** opens the modal pre-filled with the payment amount
- [ ] Fill reason + details → confirm → Stripe refund created; payment doc flips to `status: 'refunded'`
- [ ] Trying again on the same payment → 409 "already refunded"
- [ ] Non-admin / admin without `billing:refund` → 403 (currently `support` and `billing_admin` only — confirm)
- [ ] Audit log entry shows real adminId, the reason, and the Stripe refund id

## Setup
- Requires `STRIPE_SECRET_KEY` on the environment (already required for the existing Stripe flows).
- No Firestore rules changes.

## Next chunks of DEV-165 (separate PRs)
- `/admin/conversations` viewer + message moderation
- Attestation void (append-only)
- Admin-on-behalf-of match accept UI
- Account-status quick-flip on `/admin/users`

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_