### PR TITLE
Admin: attestation void (DEV-165 part 2)

### DIFF
--- a/src/app/admin/attestations/page.tsx
+++ b/src/app/admin/attestations/page.tsx
@@ -8,7 +8,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Table,
@@ -25,15 +28,33 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { useFirestore } from '@/firebase';
 import { collection, getDocs } from 'firebase/firestore';
 import { format, parseISO } from 'date-fns';
-import { Shield, Search } from 'lucide-react';
-import { ATTESTATIONS, type AttestationEntry, type AttestationType } from '@/lib/attestations';
+import { Shield, Search, Ban, Loader2 } from 'lucide-react';
+import {
+  ATTESTATIONS,
+  type AttestationEntry,
+  type AttestationType,
+  type AttestationVoid,
+} from '@/lib/attestations';
+import { useAdminRole } from '../layout';
+import { showSuccess, showError } from '@/lib/toast-utils';
 
 interface FlatAttestation extends AttestationEntry {
   ownerUid: string;
   ownerName: string;
+  voided?: AttestationVoid;
 }
 
 const SURFACE_LABELS: Record<string, string> = {
@@ -48,35 +69,86 @@ const SURFACE_LABELS: Record<string, string> = {
 
 export default function AdminAttestationsPage() {
   const firestore = useFirestore();
+  const { hasPermission } = useAdminRole();
+  const canVoid = hasPermission('users:edit');
   const [rows, setRows] = useState<FlatAttestation[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [surfaceFilter, setSurfaceFilter] = useState<string>('all');
+  const [voidingEntry, setVoidingEntry] = useState<FlatAttestation | null>(null);
+  const [voidReason, setVoidReason] = useState('');
+  const [isVoiding, setIsVoiding] = useState(false);
 
-  useEffect(() => {
-    async function load() {
-      if (!firestore) return;
-      try {
-        const snap = await getDocs(collection(firestore, 'owner_operators'));
-        const flat: FlatAttestation[] = [];
-        snap.forEach(docSnap => {
-          const data = docSnap.data() as { legalName?: string; companyName?: string; attestations?: AttestationEntry[] };
-          const ownerName = data.legalName || data.companyName || docSnap.id;
-          (data.attestations || []).forEach(entry => {
-            flat.push({ ...entry, ownerUid: docSnap.id, ownerName });
+  async function loadRows() {
+    if (!firestore) return;
+    setLoading(true);
+    try {
+      const snap = await getDocs(collection(firestore, 'owner_operators'));
+      const flat: FlatAttestation[] = [];
+      snap.forEach(docSnap => {
+        const data = docSnap.data() as {
+          legalName?: string;
+          companyName?: string;
+          attestations?: AttestationEntry[];
+          attestationVoids?: AttestationVoid[];
+        };
+        const ownerName = data.legalName || data.companyName || docSnap.id;
+        const voids = data.attestationVoids || [];
+        (data.attestations || []).forEach(entry => {
+          const matchedVoid = voids.find(
+            v => v.type === entry.type && v.entryAcceptedAt === entry.acceptedAt
+          );
+          flat.push({
+            ...entry,
+            ownerUid: docSnap.id,
+            ownerName,
+            voided: matchedVoid,
           });
         });
-        flat.sort((a, b) => (b.acceptedAt || '').localeCompare(a.acceptedAt || ''));
-        setRows(flat);
-      } catch (err) {
-        console.error('Failed to load attestations:', err);
-      } finally {
-        setLoading(false);
-      }
+      });
+      flat.sort((a, b) => (b.acceptedAt || '').localeCompare(a.acceptedAt || ''));
+      setRows(flat);
+    } catch (err) {
+      console.error('Failed to load attestations:', err);
+    } finally {
+      setLoading(false);
     }
-    load();
+  }
+
+  useEffect(() => {
+    loadRows();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [firestore]);
+
+  const handleVoid = async () => {
+    if (!voidingEntry || !voidReason.trim()) return;
+    setIsVoiding(true);
+    try {
+      const res = await fetch('/api/admin/attestations/void', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerUid: voidingEntry.ownerUid,
+          type: voidingEntry.type,
+          entryAcceptedAt: voidingEntry.acceptedAt,
+          reason: voidReason.trim(),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || 'Failed to void attestation.');
+      }
+      showSuccess('Attestation marked voided.');
+      setVoidingEntry(null);
+      setVoidReason('');
+      loadRows();
+    } catch (e: any) {
+      showError(e?.message || 'Failed to void attestation.');
+    } finally {
+      setIsVoiding(false);
+    }
+  };
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -178,8 +250,10 @@ export default function AdminAttestationsPage() {
                   <TableHead>Type</TableHead>
                   <TableHead>Surface</TableHead>
                   <TableHead>Version</TableHead>
+                  <TableHead>Status</TableHead>
                   <TableHead>Context</TableHead>
                   <TableHead>IP</TableHead>
+                  <TableHead className="w-20"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -188,7 +262,7 @@ export default function AdminAttestationsPage() {
                   const surface = def?.surface;
                   const stale = def && r.version < def.v;
                   return (
-                    <TableRow key={`${r.ownerUid}-${r.acceptedAt}-${idx}`}>
+                    <TableRow key={`${r.ownerUid}-${r.acceptedAt}-${idx}`} className={r.voided ? 'opacity-60' : ''}>
                       <TableCell className="font-mono text-xs whitespace-nowrap">
                         {(() => {
                           try {
@@ -202,12 +276,22 @@ export default function AdminAttestationsPage() {
                         <div className="font-medium">{r.ownerName}</div>
                         <div className="font-mono text-xs text-muted-foreground">{r.ownerUid}</div>
                       </TableCell>
-                      <TableCell className="text-sm">{r.type}</TableCell>
+                      <TableCell className={`text-sm ${r.voided ? 'line-through' : ''}`}>{def?.label || r.type}</TableCell>
                       <TableCell className="text-xs">{surface ? (SURFACE_LABELS[surface] || surface) : '—'}</TableCell>
                       <TableCell>
                         <Badge variant={stale ? 'outline' : 'default'} className={stale ? 'text-amber-600 border-amber-600' : ''}>
                           v{r.version}{stale && def && ` of v${def.v}`}
                         </Badge>
+                      </TableCell>
+                      <TableCell>
+                        {r.voided ? (
+                          <div className="space-y-0.5">
+                            <Badge variant="destructive">Voided</Badge>
+                            <p className="text-xs text-muted-foreground" title={r.voided.voidedReason}>{r.voided.voidedReason}</p>
+                          </div>
+                        ) : (
+                          <Badge variant="outline" className="text-green-700 border-green-300">Valid</Badge>
+                        )}
                       </TableCell>
                       <TableCell className="text-xs space-y-0.5">
                         {r.context?.matchId && <div>match: {r.context.matchId}</div>}
@@ -218,6 +302,13 @@ export default function AdminAttestationsPage() {
                         {!r.context && <span className="text-muted-foreground">—</span>}
                       </TableCell>
                       <TableCell className="font-mono text-xs">{r.ip || '—'}</TableCell>
+                      <TableCell>
+                        {canVoid && !r.voided && (
+                          <Button size="sm" variant="ghost" className="text-destructive" onClick={() => { setVoidingEntry(r); setVoidReason(''); }}>
+                            <Ban className="h-3.5 w-3.5 mr-1" />Void
+                          </Button>
+                        )}
+                      </TableCell>
                     </TableRow>
                   );
                 })}
@@ -226,6 +317,45 @@ export default function AdminAttestationsPage() {
           )}
         </CardContent>
       </Card>
+
+      <AlertDialog open={!!voidingEntry} onOpenChange={(open) => { if (!open) { setVoidingEntry(null); setVoidReason(''); } }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Void this attestation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The original attestation entry stays on the record (audit integrity); a parallel
+              void entry is added with your reason. Voided attestations render with a strike on
+              the user&apos;s profile.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {voidingEntry && (
+            <div className="rounded-lg border bg-muted/40 p-3 text-sm space-y-1">
+              <p><strong>{ATTESTATIONS[voidingEntry.type]?.label || voidingEntry.type}</strong> — {ATTESTATIONS[voidingEntry.type]?.text}</p>
+              <p className="text-xs text-muted-foreground">{voidingEntry.ownerName} · accepted {voidingEntry.acceptedAt}</p>
+            </div>
+          )}
+          <div className="py-2">
+            <Label htmlFor="void-reason">Reason for voiding</Label>
+            <Textarea
+              id="void-reason"
+              placeholder="Why is this attestation being voided?"
+              value={voidReason}
+              onChange={(e) => setVoidReason(e.target.value)}
+              className="mt-2"
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isVoiding}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleVoid}
+              disabled={isVoiding || !voidReason.trim()}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isVoiding ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Voiding...</> : 'Void Attestation'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/api/admin/attestations/void/route.ts
+++ b/src/app/api/admin/attestations/void/route.ts
@@ -1,0 +1,119 @@
+/**
+ * Admin: void an attestation entry (DEV-165).
+ *
+ * Append-only by design — the original entry stays in
+ * `owner_operators/{uid}.attestations[]` for audit integrity. A parallel
+ * `attestationVoids[]` entry is added to mark the original as no longer valid.
+ *
+ * Permission: `users:edit` (admins who can edit users can void their attestations).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+async function handlePost(request: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+
+    // 1. Authenticate.
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+    const adminEmail = decoded.email || '';
+
+    // 2. Authorize.
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'users:edit')) {
+      return json({ error: 'You do not have permission to void attestations.' }, 403);
+    }
+
+    // 3. Validate input.
+    let body: { ownerUid?: string; type?: string; entryAcceptedAt?: string; reason?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: 'Invalid request body.' }, 400);
+    }
+    const { ownerUid, type, entryAcceptedAt, reason } = body;
+    if (!ownerUid || !type || !entryAcceptedAt || !reason || !reason.trim()) {
+      return json({ error: 'ownerUid, type, entryAcceptedAt, and reason are required.' }, 400);
+    }
+
+    // 4. Confirm the attestation entry exists on the owner doc (and isn't already voided).
+    const ownerRef = db.collection('owner_operators').doc(ownerUid);
+    const ownerSnap = await ownerRef.get();
+    if (!ownerSnap.exists) {
+      return json({ error: 'Owner not found.' }, 404);
+    }
+    const ownerData = ownerSnap.data() as {
+      attestations?: { type: string; acceptedAt: string }[];
+      attestationVoids?: { type: string; entryAcceptedAt: string }[];
+    };
+    const matches = (ownerData.attestations || []).some(
+      (a) => a.type === type && a.acceptedAt === entryAcceptedAt
+    );
+    if (!matches) {
+      return json({ error: 'No matching attestation found for this owner.' }, 404);
+    }
+    const alreadyVoided = (ownerData.attestationVoids || []).some(
+      (v) => v.type === type && v.entryAcceptedAt === entryAcceptedAt
+    );
+    if (alreadyVoided) {
+      return json({ error: 'This attestation is already voided.' }, 409);
+    }
+
+    // 5. Append the void entry — original attestation stays put for audit.
+    const now = new Date().toISOString();
+    const voidEntry = {
+      type,
+      entryAcceptedAt,
+      voidedAt: now,
+      voidedBy: adminUid,
+      voidedReason: reason.trim(),
+    };
+    await ownerRef.update({
+      attestationVoids: FieldValue.arrayUnion(voidEntry),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    // 6. Audit.
+    await db.collection('audit_logs').add({
+      action: 'attestation_voided',
+      adminId: adminUid,
+      adminEmail,
+      targetType: 'user',
+      targetId: ownerUid,
+      reason: reason.trim(),
+      details: { attestationType: type, entryAcceptedAt },
+      timestamp: FieldValue.serverTimestamp(),
+      createdAt: now,
+    });
+
+    return json({ success: true, voidEntry }, 200);
+  } catch (error: any) {
+    console.error('[POST /api/admin/attestations/void]', error);
+    return json({ error: error?.message || 'Failed to void attestation.' }, 500);
+  }
+}
+
+export const POST = withCors(handlePost);

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -29,7 +29,7 @@ import { showSuccess, showError } from '@/lib/toast-utils';
 import { parseError } from '@/lib/error-utils';
 import { format, parseISO } from 'date-fns';
 import type { FMCSACarrier } from '@/lib/fmcsa';
-import { ATTESTATIONS, hasCurrent, type AttestationEntry, type AttestationType } from '@/lib/attestations';
+import { ATTESTATIONS, hasCurrent, findAttestationVoid, type AttestationEntry, type AttestationType, type AttestationVoid } from '@/lib/attestations';
 import { AttestationRecaptureSheet } from '@/components/attestation-recapture-sheet';
 import { AlertCircle } from 'lucide-react';
 
@@ -961,23 +961,36 @@ export default function ProfilePage() {
                 {profile.attestations.map((entry, idx) => {
                   const def = ATTESTATIONS[entry.type];
                   const stale = def && entry.version < def.v;
+                  const voids = (profile as unknown as { attestationVoids?: AttestationVoid[] }).attestationVoids;
+                  const voided = findAttestationVoid(voids, entry);
                   return (
-                    <div key={`${entry.type}-${entry.acceptedAt}-${idx}`} className="rounded-lg border bg-muted/30 p-3">
+                    <div
+                      key={`${entry.type}-${entry.acceptedAt}-${idx}`}
+                      className={`rounded-lg border p-3 ${voided ? 'bg-red-50/40 dark:bg-red-950/10 border-red-200 dark:border-red-900' : 'bg-muted/30'}`}
+                    >
                       <div className="flex items-start gap-2">
-                        <CheckCircle2 className={`h-4 w-4 mt-0.5 shrink-0 ${stale ? 'text-amber-500' : 'text-green-600'}`} />
+                        <CheckCircle2 className={`h-4 w-4 mt-0.5 shrink-0 ${voided ? 'text-red-500' : stale ? 'text-amber-500' : 'text-green-600'}`} />
                         <div className="flex-1">
-                          <p className="text-sm font-medium">
+                          <p className={`text-sm font-medium ${voided ? 'line-through text-muted-foreground' : ''}`}>
                             {def?.label || entry.type}
-                            <span className="ml-2 text-xs text-muted-foreground font-normal">
+                            <span className="ml-2 text-xs text-muted-foreground font-normal no-underline">
                               v{entry.version}{stale && ` (current: v${def.v})`}
                             </span>
+                            {voided && (
+                              <span className="ml-2 inline-flex items-center rounded-md bg-red-100 dark:bg-red-950/30 px-1.5 py-0.5 text-xs font-medium text-red-700 dark:text-red-300 no-underline">Voided</span>
+                            )}
                           </p>
-                          <p className="text-xs text-muted-foreground mt-0.5">{entry.text}</p>
+                          <p className={`text-xs text-muted-foreground mt-0.5 ${voided ? 'line-through' : ''}`}>{entry.text}</p>
                           <p className="text-xs text-muted-foreground mt-1">
                             Accepted: {formatTimestamp(entry.acceptedAt)}
                             {entry.context?.matchId && <> · match {entry.context.matchId}</>}
                             {entry.context?.driverId && <> · driver {entry.context.driverId}</>}
                           </p>
+                          {voided && (
+                            <p className="text-xs text-red-700 dark:text-red-300 mt-1">
+                              Voided by admin {formatTimestamp(voided.voidedAt)} — {voided.voidedReason}
+                            </p>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/src/lib/attestations.ts
+++ b/src/lib/attestations.ts
@@ -310,3 +310,39 @@ export function attestationsForSurface(
   if (!attestations) return [];
   return attestations.filter(a => ATTESTATIONS[a.type]?.surface === surface);
 }
+
+/**
+ * Append-only record of admin-voided attestations. The original entry stays
+ * in `attestations[]` (audit integrity); a void entry is added in parallel
+ * to mark it as no longer valid.
+ */
+export interface AttestationVoid {
+  /** Attestation type that was voided. */
+  type: AttestationType;
+  /** ISO `acceptedAt` of the entry being voided — pairs with `type` to identify it uniquely. */
+  entryAcceptedAt: string;
+  /** ISO timestamp of when the admin voided it. */
+  voidedAt: string;
+  /** uid of the admin who voided the attestation. */
+  voidedBy: string;
+  /** Admin's reason for voiding (audit). */
+  voidedReason: string;
+}
+
+/** True if the given attestation entry has been voided by an admin. */
+export function isAttestationVoided(
+  voids: AttestationVoid[] | undefined,
+  entry: Pick<AttestationEntry, 'type' | 'acceptedAt'>,
+): boolean {
+  if (!voids || voids.length === 0) return false;
+  return voids.some(v => v.type === entry.type && v.entryAcceptedAt === entry.acceptedAt);
+}
+
+/** Look up the void record for a given attestation entry, if any. */
+export function findAttestationVoid(
+  voids: AttestationVoid[] | undefined,
+  entry: Pick<AttestationEntry, 'type' | 'acceptedAt'>,
+): AttestationVoid | undefined {
+  if (!voids) return undefined;
+  return voids.find(v => v.type === entry.type && v.entryAcceptedAt === entry.acceptedAt);
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -21,6 +21,7 @@ export type AuditAction =
   | 'tla_updated'
   | 'tla_deleted'
   | 'billing_refunded'
+  | 'attestation_voided'
   | 'admin_login'
   | 'data_exported';
 
@@ -72,6 +73,7 @@ export function getActionLabel(action: AuditAction): string {
     tla_updated: 'TLA Updated',
     tla_deleted: 'TLA Deleted',
     billing_refunded: 'Payment Refunded',
+    attestation_voided: 'Attestation Voided',
     admin_login: 'Admin Login',
     data_exported: 'Data Exported',
   };


### PR DESCRIPTION
Second chunk of **DEV-165**. Lets an admin void an erroneous attestation without deleting it — audit integrity is the entire point of attestations, so deletion is off the table.

## Data model
- New `AttestationVoid` type + `findAttestationVoid` helper in `src/lib/attestations.ts`.
- The original `AttestationEntry` stays in `owner_operators[].attestations[]`; a parallel `owner_operators[].attestationVoids[]` is appended via `arrayUnion` to mark the original as no longer valid.
- An entry is uniquely identified by `(type, entryAcceptedAt)`.

## Server
- `POST /api/admin/attestations/void` — admin-gated (`users:edit`), validates the entry exists, refuses re-voiding (409), writes via `arrayUnion`, audit-logs as `attestation_voided`.

## UI
- **`/admin/attestations`** — new Status column (Valid / Voided + reason), uses the attestation label (not the code key), and each non-voided row gets a **Void** action that opens a confirm dialog asking for a reason.
- **`/dashboard/profile`** — voided attestations render with a strike-through, a *Voided* badge, and the admin's reason; non-voided entries look the same as before.

## Test plan
- [ ] `/admin/attestations` shows every entry; voided ones display "Voided" + reason and are visually muted
- [ ] Clicking **Void** on a valid entry opens a dialog; reason is required
- [ ] After voiding, the row updates inline and `audit_logs` shows `attestation_voided`
- [ ] Voiding twice → 409 "already voided"
- [ ] Visit that user's profile → the entry shows the strike + reason; other entries unchanged

## Setup
No Firestore rules changes; `attestationVoids` is written via the Admin SDK.

## Next chunks of DEV-165
- Admin-on-behalf-of match accept UI on `/admin/matches`
- `/admin/conversations` viewer + message moderation
- (Maybe) account-status quick-flip on `/admin/users` — currently already accessible via Edit User → Account Status, so this one's low-priority

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_