### PR TITLE
Admin: /admin/conversations viewer + message moderation (DEV-165 part 4)

### DIFF
--- a/src/app/admin/conversations/page.tsx
+++ b/src/app/admin/conversations/page.tsx
@@ -1,0 +1,398 @@
+'use client';
+
+/**
+ * /admin/conversations — DEV-165: admin / support view of all conversations
+ * across the platform, with the ability to soft-delete individual messages
+ * for dispute resolution and moderation.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { format } from 'date-fns';
+import { MessageSquare, Search, Trash2, Loader2, RefreshCw } from 'lucide-react';
+import { showError, showSuccess } from '@/lib/toast-utils';
+import { useAdminRole } from '../layout';
+
+interface Conversation {
+  id: string;
+  participants?: string[];
+  participantDetails?: Record<string, { companyName?: string; email?: string }>;
+  loadDetails?: { origin?: string; destination?: string; cargo?: string };
+  tlaId?: string;
+  lastMessage?: string;
+  lastMessageAt?: string;
+  createdAt?: string;
+}
+
+interface Message {
+  id: string;
+  text?: string;
+  originalText?: string;
+  senderId?: string;
+  senderName?: string;
+  createdAt?: any;
+  deletedAt?: string;
+  deletedBy?: string;
+  deletedReason?: string;
+}
+
+function formatTimestamp(ts: any): string {
+  if (!ts) return '—';
+  try {
+    const d = typeof ts === 'string' ? new Date(ts) : ts?.toDate ? ts.toDate() : new Date(ts);
+    return format(d, 'PPp');
+  } catch {
+    return String(ts);
+  }
+}
+
+function summarizeParticipants(c: Conversation): string {
+  if (!c.participantDetails) return '—';
+  const names = Object.values(c.participantDetails).map(
+    (p) => p?.companyName || p?.email || '?'
+  );
+  return names.join(' ↔ ');
+}
+
+export default function AdminConversationsPage() {
+  const { hasPermission } = useAdminRole();
+  const canView = hasPermission('audit:view');
+  const canModerate = hasPermission('users:edit');
+
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  const [openConv, setOpenConv] = useState<Conversation | null>(null);
+  const [messages, setMessages] = useState<Message[] | null>(null);
+  const [loadingMessages, setLoadingMessages] = useState(false);
+
+  const [deletingMessage, setDeletingMessage] = useState<Message | null>(null);
+  const [deleteReason, setDeleteReason] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function loadConversations() {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/admin/conversations');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to load conversations.');
+      setConversations(data.conversations || []);
+    } catch (e: any) {
+      showError(e?.message || 'Failed to load conversations.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function openConversation(conv: Conversation) {
+    setOpenConv(conv);
+    setMessages(null);
+    setLoadingMessages(true);
+    try {
+      const res = await fetch(`/api/admin/conversations/${encodeURIComponent(conv.id)}/messages`);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to load messages.');
+      setMessages(data.messages || []);
+    } catch (e: any) {
+      showError(e?.message || 'Failed to load messages.');
+      setMessages([]);
+    } finally {
+      setLoadingMessages(false);
+    }
+  }
+
+  async function handleDeleteMessage() {
+    if (!openConv || !deletingMessage) return;
+    setIsDeleting(true);
+    try {
+      const res = await fetch(
+        `/api/admin/conversations/${encodeURIComponent(openConv.id)}/messages/delete`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messageId: deletingMessage.id, reason: deleteReason.trim() }),
+        }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to delete message.');
+      showSuccess('Message removed.');
+      setDeletingMessage(null);
+      setDeleteReason('');
+      // Refresh messages.
+      openConversation(openConv);
+    } catch (e: any) {
+      showError(e?.message || 'Failed to delete message.');
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  useEffect(() => {
+    if (canView) loadConversations();
+  }, [canView]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return conversations;
+    return conversations.filter((c) => {
+      const partsText = c.participantDetails
+        ? Object.values(c.participantDetails)
+            .map((p) => `${p?.companyName || ''} ${p?.email || ''}`)
+            .join(' ')
+        : '';
+      return (
+        c.id.toLowerCase().includes(q) ||
+        partsText.toLowerCase().includes(q) ||
+        (c.loadDetails?.origin || '').toLowerCase().includes(q) ||
+        (c.loadDetails?.destination || '').toLowerCase().includes(q) ||
+        (c.lastMessage || '').toLowerCase().includes(q)
+      );
+    });
+  }, [conversations, search]);
+
+  if (!canView) {
+    return (
+      <Card className="mx-auto max-w-lg">
+        <CardHeader>
+          <CardTitle>No access</CardTitle>
+          <CardDescription>Your admin role can&apos;t view conversations.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <div>
+          <h1 className="text-3xl font-bold font-headline flex items-center gap-2">
+            <MessageSquare className="h-7 w-7" />
+            Conversations
+          </h1>
+          <p className="text-muted-foreground">
+            All conversations across the platform — for dispute resolution and moderation.
+          </p>
+        </div>
+        <Button variant="outline" onClick={loadConversations} disabled={loading}>
+          <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />Refresh
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <CardTitle>Conversations</CardTitle>
+              <CardDescription>{filtered.length} of {conversations.length}</CardDescription>
+            </div>
+            <div className="relative w-64">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search participants, route, last message…"
+                className="pl-8"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-8 text-center">No conversations match the current filters.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Participants</TableHead>
+                  <TableHead>Route</TableHead>
+                  <TableHead>Last Message</TableHead>
+                  <TableHead>Last Activity</TableHead>
+                  <TableHead className="w-24"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((c) => (
+                  <TableRow key={c.id} className="hover:bg-muted/50">
+                    <TableCell className="text-sm">
+                      <div className="font-medium">{summarizeParticipants(c)}</div>
+                      {c.tlaId && <div className="text-xs text-muted-foreground">TLA: {c.tlaId}</div>}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {c.loadDetails?.origin || '?'} → {c.loadDetails?.destination || '?'}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground max-w-md truncate">
+                      {c.lastMessage || '—'}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                      {formatTimestamp(c.lastMessageAt)}
+                    </TableCell>
+                    <TableCell>
+                      <Button variant="outline" size="sm" onClick={() => openConversation(c)}>
+                        Open
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Conversation detail dialog */}
+      <Dialog open={!!openConv} onOpenChange={(open) => { if (!open) { setOpenConv(null); setMessages(null); } }}>
+        <DialogContent className="max-w-2xl max-h-[90vh]">
+          <DialogHeader>
+            <DialogTitle>Conversation</DialogTitle>
+            <DialogDescription>
+              {openConv && summarizeParticipants(openConv)}
+              {openConv?.loadDetails && (
+                <> &middot; {openConv.loadDetails.origin} → {openConv.loadDetails.destination}</>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <ScrollArea className="max-h-[65vh] pr-4">
+            {loadingMessages ? (
+              <div className="space-y-2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-12 w-3/4" />
+                ))}
+              </div>
+            ) : !messages || messages.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-8 text-center">No messages.</p>
+            ) : (
+              <div className="space-y-3">
+                {messages.map((m) => {
+                  const senderLabel =
+                    m.senderName ||
+                    (m.senderId && openConv?.participantDetails?.[m.senderId]?.companyName) ||
+                    m.senderId ||
+                    'Unknown';
+                  return (
+                    <div
+                      key={m.id}
+                      className={`rounded-lg border p-3 ${m.deletedAt ? 'bg-red-50/40 dark:bg-red-950/10 border-red-200 dark:border-red-900' : 'bg-muted/30'}`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                            <span className="font-medium">{senderLabel}</span>
+                            <span>·</span>
+                            <span>{formatTimestamp(m.createdAt)}</span>
+                            {m.deletedAt && <Badge variant="destructive" className="ml-2">Deleted</Badge>}
+                          </div>
+                          <p className={`text-sm mt-1 whitespace-pre-wrap ${m.deletedAt ? 'italic text-muted-foreground' : ''}`}>
+                            {m.text || ''}
+                          </p>
+                          {m.deletedAt && (
+                            <p className="text-xs text-muted-foreground mt-1">
+                              Deleted {formatTimestamp(m.deletedAt)}
+                              {m.deletedReason && <> — {m.deletedReason}</>}
+                              {m.originalText && (
+                                <span className="block mt-1">Original: <span className="italic">{m.originalText}</span></span>
+                              )}
+                            </p>
+                          )}
+                        </div>
+                        {canModerate && !m.deletedAt && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="text-destructive shrink-0"
+                            onClick={() => { setDeletingMessage(m); setDeleteReason(''); }}
+                          >
+                            <Trash2 className="h-3.5 w-3.5 mr-1" />Delete
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </ScrollArea>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setOpenConv(null); setMessages(null); }}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete message confirm */}
+      <AlertDialog open={!!deletingMessage} onOpenChange={(open) => { if (!open) { setDeletingMessage(null); setDeleteReason(''); } }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this message?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The original text is preserved on the record for audit. The displayed message is replaced
+              with &ldquo;[Message removed by admin]&rdquo; for participants.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deletingMessage && (
+            <div className="rounded-lg border bg-muted/40 p-3 text-sm">
+              <p className="whitespace-pre-wrap text-xs italic">{deletingMessage.text}</p>
+            </div>
+          )}
+          <div className="py-2">
+            <Label htmlFor="delete-reason">Reason (optional)</Label>
+            <Textarea
+              id="delete-reason"
+              placeholder="Why is this message being removed?"
+              value={deleteReason}
+              onChange={(e) => setDeleteReason(e.target.value)}
+              className="mt-2"
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteMessage}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Removing…</> : 'Remove Message'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -28,7 +28,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Logo } from "@/components/logo";
-import { Home, Users, Truck, LogOut, Loader2, FileText, Link2, Shield, ClipboardList, Package, Settings, CreditCard, UserPlus } from "lucide-react";
+import { Home, Users, Truck, LogOut, Loader2, FileText, Link2, Shield, ClipboardList, Package, Settings, CreditCard, UserPlus, MessageSquare } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -110,6 +110,11 @@ function AdminSidebarNav({ onSignOutClick, adminRole }: { onSignOutClick: () => 
           {checkPermission('audit:view') && (
             <SidebarMenuItem>
               <AdminSidebarNavLink href="/admin/audit" tooltip="Audit Log"><ClipboardList /><span>Audit Log</span></AdminSidebarNavLink>
+            </SidebarMenuItem>
+          )}
+          {checkPermission('audit:view') && (
+            <SidebarMenuItem>
+              <AdminSidebarNavLink href="/admin/conversations" tooltip="Conversations"><MessageSquare /><span>Conversations</span></AdminSidebarNavLink>
             </SidebarMenuItem>
           )}
           {checkPermission('billing:view') && (

--- a/src/app/api/admin/conversations/[id]/messages/delete/route.ts
+++ b/src/app/api/admin/conversations/[id]/messages/delete/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Admin: soft-delete a message in a conversation (DEV-165).
+ *
+ * Soft delete — the message doc stays, but gets `deletedAt`, `deletedBy`,
+ * and `deletedReason` set; the original text is preserved in `originalText`
+ * if not already so. The conversations Firestore rules are unchanged
+ * (participants only); admins go through this server route, which uses the
+ * Admin SDK and bypasses rules.
+ *
+ * Permission: `users:edit` (more sensitive than just viewing).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+async function handlePost(request: NextRequest, conversationId: string) {
+  try {
+    if (!conversationId) return json({ error: 'A conversation id is required.' }, 400);
+
+    const { auth, db } = await getFirebaseAdmin();
+
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+    const adminEmail = decoded.email || '';
+
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'users:edit')) {
+      return json({ error: 'You do not have permission to delete messages.' }, 403);
+    }
+
+    let body: { messageId?: string; reason?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: 'Invalid request body.' }, 400);
+    }
+    const { messageId, reason } = body;
+    if (!messageId) return json({ error: 'messageId is required.' }, 400);
+
+    const messageRef = db
+      .collection('conversations')
+      .doc(conversationId)
+      .collection('messages')
+      .doc(messageId);
+    const messageSnap = await messageRef.get();
+    if (!messageSnap.exists) {
+      return json({ error: 'Message not found.' }, 404);
+    }
+    const messageData = messageSnap.data() as { text?: string; originalText?: string; deletedAt?: string };
+    if (messageData.deletedAt) {
+      return json({ error: 'This message is already deleted.' }, 409);
+    }
+
+    const now = new Date().toISOString();
+    // Preserve the original text the first time we delete (idempotent).
+    const update: Record<string, unknown> = {
+      deletedAt: now,
+      deletedBy: adminUid,
+      deletedReason: (reason || '').trim(),
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    if (!messageData.originalText && messageData.text) {
+      update.originalText = messageData.text;
+    }
+    update.text = '[Message removed by admin]';
+    await messageRef.update(update);
+
+    await db.collection('audit_logs').add({
+      action: 'message_deleted',
+      adminId: adminUid,
+      adminEmail,
+      targetType: 'system',
+      targetId: `conversations/${conversationId}/messages/${messageId}`,
+      reason: (reason || '').trim(),
+      details: { conversationId, messageId },
+      timestamp: FieldValue.serverTimestamp(),
+      createdAt: now,
+    });
+
+    return json({ success: true }, 200);
+  } catch (error: any) {
+    console.error('[POST /api/admin/conversations/:id/messages/delete]', error);
+    return json({ error: 'Failed to delete message.' }, 500);
+  }
+}
+
+export const POST = withCors((req: NextRequest) => {
+  // /api/admin/conversations/[id]/messages/delete
+  const parts = req.nextUrl.pathname.split('/');
+  const id = parts[4];
+  return handlePost(req, id);
+});

--- a/src/app/api/admin/conversations/[id]/messages/route.ts
+++ b/src/app/api/admin/conversations/[id]/messages/route.ts
@@ -1,0 +1,72 @@
+/**
+ * Admin: list messages in a conversation (DEV-165).
+ *
+ * Includes soft-deleted messages (with deletedAt / deletedBy / deletedReason
+ * intact) so the audit trail is complete.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirebaseAdmin } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+async function handleGet(request: NextRequest, conversationId: string) {
+  try {
+    if (!conversationId) return json({ error: 'A conversation id is required.' }, 400);
+
+    const { auth, db } = await getFirebaseAdmin();
+
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'audit:view')) {
+      return json({ error: 'You do not have permission to view conversations.' }, 403);
+    }
+
+    const convSnap = await db.collection('conversations').doc(conversationId).get();
+    if (!convSnap.exists) {
+      return json({ error: 'Conversation not found.' }, 404);
+    }
+    const conversation = { id: convSnap.id, ...convSnap.data() };
+
+    const messagesSnap = await db
+      .collection('conversations')
+      .doc(conversationId)
+      .collection('messages')
+      .orderBy('createdAt', 'asc')
+      .limit(500)
+      .get();
+    const messages = messagesSnap.docs.map((d: FirebaseFirestore.QueryDocumentSnapshot) => ({ id: d.id, ...d.data() }));
+    return json({ conversation, messages }, 200);
+  } catch (error: any) {
+    console.error('[GET /api/admin/conversations/:id/messages]', error);
+    return json({ error: 'Failed to load messages.' }, 500);
+  }
+}
+
+export const GET = withCors((req: NextRequest) => {
+  // /api/admin/conversations/[id]/messages
+  const parts = req.nextUrl.pathname.split('/');
+  const id = parts[4];
+  return handleGet(req, id);
+});

--- a/src/app/api/admin/conversations/route.ts
+++ b/src/app/api/admin/conversations/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Admin: list all conversations across the platform (DEV-165).
+ *
+ * Permission: `audit:view` (support, admin, super_admin).
+ * Server-mediated so this admin path doesn't require relaxing the
+ * conversations Firestore rules (which scope reads to participants).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirebaseAdmin } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+async function handleGet(request: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'audit:view')) {
+      return json({ error: 'You do not have permission to view conversations.' }, 403);
+    }
+
+    // Newest activity first.
+    const snap = await db.collection('conversations').orderBy('lastMessageAt', 'desc').limit(200).get();
+    const conversations = snap.docs.map((d: FirebaseFirestore.QueryDocumentSnapshot) => ({ id: d.id, ...d.data() }));
+    return json({ conversations }, 200);
+  } catch (error: any) {
+    console.error('[GET /api/admin/conversations]', error);
+    return json({ error: 'Failed to load conversations.' }, 500);
+  }
+}
+
+export const GET = withCors(handleGet);

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -22,6 +22,7 @@ export type AuditAction =
   | 'tla_deleted'
   | 'billing_refunded'
   | 'attestation_voided'
+  | 'message_deleted'
   | 'admin_login'
   | 'data_exported';
 
@@ -74,6 +75,7 @@ export function getActionLabel(action: AuditAction): string {
     tla_deleted: 'TLA Deleted',
     billing_refunded: 'Payment Refunded',
     attestation_voided: 'Attestation Voided',
+    message_deleted: 'Message Deleted',
     admin_login: 'Admin Login',
     data_exported: 'Data Exported',
   };


### PR DESCRIPTION
Fourth (and final big) chunk of **DEV-165**. Closes the audit's "no admin view of conversations" gap — support / admins can now read every conversation on the platform for dispute resolution and soft-delete individual messages for moderation.

## UI
- New **`/admin/conversations`** page (gated on `audit:view`).
- Lists every conversation by `lastMessageAt`, with search across participants, route, last message.
- Drill-in dialog shows the full message timeline; deleted messages render with a strike, the admin's reason, and the original text preserved for audit.
- Per-message **Delete** action gated on `users:edit`; confirm dialog with an optional reason.
- New **Conversations** entry in the admin sidebar (gated on `audit:view`).

## Server routes (Admin SDK; Firestore conversation rules unchanged)
- `GET /api/admin/conversations` — list (`audit:view`).
- `GET /api/admin/conversations/[id]/messages` — timeline (`audit:view`).
- `POST /api/admin/conversations/[id]/messages/delete` — soft delete (`users:edit`).
  - Preserves the original text in `originalText`, replaces `text` with `[Message removed by admin]`, writes `deletedAt` / `deletedBy` / `deletedReason`.
  - Idempotent — re-deleting returns 409.
  - Audit-logged as `message_deleted`.

Server-mediated so participants' Firestore rules don't have to be relaxed for admin access.

## Test plan
- [ ] As a super-admin (or anyone with `audit:view`), go to **Conversations** in the sidebar
- [ ] Recent conversations appear; search filters them
- [ ] Click **Open** → message timeline loads, sender + timestamps render
- [ ] As admin, click **Delete** on a message → enter a reason → confirm; message renders with strike + reason + original text visible to admin
- [ ] Participants of that conversation see `[Message removed by admin]` instead of the original
- [ ] `/admin/audit` shows `message_deleted` with the matched IDs
- [ ] As `support` (audit:view but not users:edit) → Delete button is hidden; viewing works

## Remaining DEV-165
- Account-status quick-flip on `/admin/users` — low priority, already accessible via *Edit User → Account Status*. Happy to skip or do as a small follow-up.
- Bulk-delete a whole conversation (super_admin only) — was in the original scope but I left it out; per-message moderation covers the vast majority of needs. Easy to add later.

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_