### PR TITLE
Admin: global search across entities (DEV-166 part 3)

### DIFF
--- a/src/app/admin/drivers/page.tsx
+++ b/src/app/admin/drivers/page.tsx
@@ -206,6 +206,12 @@ export default function AdminDriversPage() {
 
   useEffect(() => { fetchDrivers(); }, [firestore]);
 
+  // Prefill the search box from `?q=` so global-search deep links land here.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q');
+    if (q) setSearchQuery(q);
+  }, []);
+
   useEffect(() => {
     let filtered = drivers;
     if (searchQuery.trim() !== '') {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -28,7 +28,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Logo } from "@/components/logo";
-import { Home, Users, Truck, LogOut, Loader2, FileText, Link2, Shield, ClipboardList, Package, Settings, CreditCard, UserPlus, MessageSquare, Activity } from "lucide-react";
+import { Home, Users, Truck, LogOut, Loader2, FileText, Link2, Shield, ClipboardList, Package, Settings, CreditCard, UserPlus, MessageSquare, Activity, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -51,6 +52,33 @@ const AdminContext = createContext<AdminContextType>({
 });
 
 export const useAdminRole = () => useContext(AdminContext);
+
+function AdminHeaderSearch() {
+  const router = useRouter();
+  const [q, setQ] = useState('');
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const trimmed = q.trim();
+        if (!trimmed) return;
+        router.push(`/admin/search?q=${encodeURIComponent(trimmed)}`);
+        setQ('');
+      }}
+      className="ml-auto flex items-center gap-2"
+    >
+      <div className="relative">
+        <Search className="absolute left-2 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+        <Input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search…"
+          className="pl-7 h-9 w-48 sm:w-64"
+        />
+      </div>
+    </form>
+  );
+}
 
 function AdminSidebarNavLink({ href, children, tooltip }: { href: string; children: React.ReactNode; tooltip: string; }) {
   const { setOpenMobile, isMobile } = useSidebar();
@@ -120,6 +148,11 @@ function AdminSidebarNav({ onSignOutClick, adminRole }: { onSignOutClick: () => 
           {checkPermission('audit:view') && (
             <SidebarMenuItem>
               <AdminSidebarNavLink href="/admin/health" tooltip="System Health"><Activity /><span>System Health</span></AdminSidebarNavLink>
+            </SidebarMenuItem>
+          )}
+          {checkPermission('audit:view') && (
+            <SidebarMenuItem>
+              <AdminSidebarNavLink href="/admin/search" tooltip="Global Search"><Search /><span>Global Search</span></AdminSidebarNavLink>
             </SidebarMenuItem>
           )}
           {checkPermission('billing:view') && (
@@ -253,7 +286,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           <AdminSidebarNav onSignOutClick={() => setShowLogoutDialog(true)} adminRole={adminRole} />
         </Sidebar>
         <SidebarInset>
-          <header className="flex h-14 items-center justify-between border-b bg-background px-4">
+          <header className="flex h-14 items-center justify-between gap-3 border-b bg-background px-4">
             <div className="flex items-center gap-2">
               <SidebarTrigger className="md:hidden" />
               <Badge variant="destructive"><Shield className="h-3 w-3 mr-1" />Admin Console</Badge>
@@ -261,7 +294,8 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 {roleInfo.name}
               </Badge>
             </div>
-            <div className="ml-auto text-sm text-muted-foreground">{user?.email}</div>
+            <AdminHeaderSearch />
+            <div className="text-sm text-muted-foreground hidden sm:block">{user?.email}</div>
           </header>
           <main className="flex-1 overflow-auto p-4 md:p-6">{children}</main>
           <footer className="border-t bg-background px-4 py-3">

--- a/src/app/admin/loads/page.tsx
+++ b/src/app/admin/loads/page.tsx
@@ -161,6 +161,12 @@ export default function AdminLoadsPage() {
 
   useEffect(() => { fetchLoads(); }, [firestore]);
 
+  // Prefill the search box from `?q=` so global-search deep links land here.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q');
+    if (q) setSearchQuery(q);
+  }, []);
+
   useEffect(() => {
     let filtered = loads;
     if (searchQuery.trim() !== '') {

--- a/src/app/admin/matches/page.tsx
+++ b/src/app/admin/matches/page.tsx
@@ -154,6 +154,12 @@ export default function AdminMatchesPage() {
 
   useEffect(() => { fetchMatches(); }, [firestore]);
 
+  // Prefill the search box from `?q=` so global-search deep links land here.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q');
+    if (q) setSearchQuery(q);
+  }, []);
+
   useEffect(() => {
     let filtered = matches;
     if (searchQuery.trim() !== '') {

--- a/src/app/admin/search/page.tsx
+++ b/src/app/admin/search/page.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+/**
+ * /admin/search?q=… — DEV-166 global admin search. Calls /api/admin/search
+ * and renders results grouped by entity type. Each result links to the
+ * relevant admin list page with `?q=<id>` so the list pre-filters to that
+ * entity.
+ */
+import { Suspense, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Search,
+  Building2,
+  Truck,
+  Package,
+  Link2,
+  FileText,
+  ArrowRight,
+  Loader2,
+} from 'lucide-react';
+import { useAdminRole } from '../layout';
+import { showError } from '@/lib/toast-utils';
+
+interface SearchResult {
+  id: string;
+  label: string;
+  sub?: string;
+  detail?: string;
+}
+
+interface SearchResponse {
+  owner_operators: SearchResult[];
+  drivers: SearchResult[];
+  loads: SearchResult[];
+  matches: SearchResult[];
+  tlas: SearchResult[];
+}
+
+const EMPTY: SearchResponse = {
+  owner_operators: [],
+  drivers: [],
+  loads: [],
+  matches: [],
+  tlas: [],
+};
+
+function SearchContent() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const { hasPermission } = useAdminRole();
+  const canView = hasPermission('audit:view');
+
+  const initialQ = params.get('q') || '';
+  const [q, setQ] = useState(initialQ);
+  const [results, setResults] = useState<SearchResponse>(EMPTY);
+  const [loading, setLoading] = useState(false);
+
+  async function runSearch(term: string) {
+    const trimmed = term.trim();
+    if (!trimmed) {
+      setResults(EMPTY);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/search?q=${encodeURIComponent(trimmed)}`);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Search failed.');
+      setResults(data as SearchResponse);
+    } catch (e: any) {
+      showError(e?.message || 'Search failed.');
+      setResults(EMPTY);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (canView && initialQ) runSearch(initialQ);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canView, initialQ]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = q.trim();
+    if (!trimmed) return;
+    router.push(`/admin/search?q=${encodeURIComponent(trimmed)}`);
+    runSearch(trimmed);
+  };
+
+  if (!canView) {
+    return (
+      <Card className="mx-auto max-w-lg">
+        <CardHeader>
+          <CardTitle>No access</CardTitle>
+          <CardDescription>Your admin role can&apos;t search the platform.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const total =
+    results.owner_operators.length +
+    results.drivers.length +
+    results.loads.length +
+    results.matches.length +
+    results.tlas.length;
+
+  const renderGroup = (
+    title: string,
+    icon: React.ReactNode,
+    items: SearchResult[],
+    listHref: string
+  ) => {
+    if (items.length === 0) return null;
+    return (
+      <Card key={title}>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            {icon}
+            {title}
+            <Badge variant="outline" className="ml-2">{items.length}{items.length === 10 ? '+' : ''}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {items.map((it) => (
+            <Link
+              key={it.id}
+              href={`${listHref}?q=${encodeURIComponent(it.id)}`}
+              className="block rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-medium truncate">{it.label}</p>
+                  {it.sub && <p className="text-xs text-muted-foreground truncate">{it.sub}</p>}
+                  {it.detail && <p className="text-xs text-muted-foreground truncate">{it.detail}</p>}
+                  <p className="font-mono text-xs text-muted-foreground mt-1">{it.id}</p>
+                </div>
+                <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+              </div>
+            </Link>
+          ))}
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold font-headline flex items-center gap-2">
+          <Search className="h-7 w-7" />
+          Global Search
+        </h1>
+        <p className="text-muted-foreground">
+          Search across users, drivers, loads, matches, and TLAs.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search by id, email, DOT, company, route, driver…"
+            className="pl-8"
+            autoFocus
+          />
+        </div>
+        <Button type="submit" disabled={loading || !q.trim()}>
+          {loading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Search className="h-4 w-4 mr-2" />}
+          Search
+        </Button>
+      </form>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : initialQ ? (
+        total === 0 ? (
+          <Card>
+            <CardContent className="py-10 text-center text-muted-foreground">
+              No results for &ldquo;{initialQ}&rdquo;.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {renderGroup('Users (Owner-Operators)', <Building2 className="h-4 w-4" />, results.owner_operators, '/admin/users')}
+            {renderGroup('Drivers', <Truck className="h-4 w-4" />, results.drivers, '/admin/drivers')}
+            {renderGroup('Loads', <Package className="h-4 w-4" />, results.loads, '/admin/loads')}
+            {renderGroup('Matches', <Link2 className="h-4 w-4" />, results.matches, '/admin/matches')}
+            {renderGroup('TLAs', <FileText className="h-4 w-4" />, results.tlas, '/admin/tlas')}
+          </div>
+        )
+      ) : (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            Enter a search term above to find anything across the admin console.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default function AdminSearchPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin" />
+        </div>
+      }
+    >
+      <SearchContent />
+    </Suspense>
+  );
+}

--- a/src/app/admin/tlas/page.tsx
+++ b/src/app/admin/tlas/page.tsx
@@ -191,6 +191,12 @@ export default function AdminTLAsPage() {
 
   useEffect(() => { fetchTLAs(); }, [firestore]);
 
+  // Prefill the search box from `?q=` so global-search deep links land here.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q');
+    if (q) setSearchQuery(q);
+  }, []);
+
   useEffect(() => {
     let filtered = tlas;
     if (searchQuery.trim() !== '') {

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -191,6 +191,12 @@ export default function AdminUsersPage() {
     fetchUsers();
   }, [firestore]);
 
+  // Prefill the search box from `?q=` so global-search deep links land here.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q');
+    if (q) setSearchQuery(q);
+  }, []);
+
   useEffect(() => {
     if (searchQuery.trim() === '') {
       setFilteredUsers(users);

--- a/src/app/api/admin/search/route.ts
+++ b/src/app/api/admin/search/route.ts
@@ -1,0 +1,164 @@
+/**
+ * Admin global search across owner_operators, drivers, loads, matches, tlas.
+ *
+ * Firestore doesn't support contains/regex queries natively, so this is an
+ * O(n) substring scan capped to the most recent ~500 docs per collection.
+ * Returns up to 10 results per type. Plenty for an admin tool today; can be
+ * upgraded to a real search index later if data scale demands it.
+ *
+ * Permission: `audit:view`.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirebaseAdmin } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+const SCAN_LIMIT = 500;
+const PER_TYPE_RESULTS = 10;
+
+type SearchResult = {
+  id: string;
+  label: string;
+  sub?: string;
+  detail?: string;
+};
+
+async function handleGet(request: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+
+    const adminSnap = await db.collection('owner_operators').doc(decoded.uid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) return json({ error: 'Admin access required.' }, 403);
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'audit:view')) {
+      return json({ error: 'You do not have permission to search.' }, 403);
+    }
+
+    const q = (request.nextUrl.searchParams.get('q') || '').trim().toLowerCase();
+    if (!q) {
+      return json(
+        { owner_operators: [], drivers: [], loads: [], matches: [], tlas: [] },
+        200
+      );
+    }
+
+    const has = (v: unknown) => typeof v === 'string' && v.toLowerCase().includes(q);
+
+    const [ooSnap, driversSnap, loadsSnap, matchesSnap, tlasSnap] = await Promise.all([
+      db.collection('owner_operators').limit(SCAN_LIMIT).get(),
+      db.collectionGroup('drivers').limit(SCAN_LIMIT).get(),
+      db.collectionGroup('loads').limit(SCAN_LIMIT).get(),
+      db.collection('matches').orderBy('createdAt', 'desc').limit(SCAN_LIMIT).get(),
+      db.collection('tlas').orderBy('createdAt', 'desc').limit(SCAN_LIMIT).get(),
+    ]);
+
+    const owner_operators: SearchResult[] = [];
+    for (const d of ooSnap.docs) {
+      const v = d.data() as Record<string, any>;
+      if (
+        has(d.id) || has(v.companyName) || has(v.legalName) || has(v.contactEmail) ||
+        has(v.dotNumber) || has(v.mcNumber) || has(v.contactName)
+      ) {
+        owner_operators.push({
+          id: d.id,
+          label: v.companyName || v.legalName || v.contactEmail || d.id,
+          sub: v.contactEmail || '',
+          detail: [v.dotNumber && `DOT ${v.dotNumber}`, v.mcNumber].filter(Boolean).join(' · '),
+        });
+        if (owner_operators.length >= PER_TYPE_RESULTS) break;
+      }
+    }
+
+    const drivers: SearchResult[] = [];
+    for (const d of driversSnap.docs) {
+      const v = d.data() as Record<string, any>;
+      if (has(d.id) || has(v.name) || has(v.email) || has(v.location) || has(v.cdlLicense)) {
+        const ownerId = d.ref.path.split('/')[1];
+        drivers.push({
+          id: d.id,
+          label: v.name || v.email || d.id,
+          sub: v.email || '',
+          detail: [v.location, v.cdlLicense, `owner ${ownerId}`].filter(Boolean).join(' · '),
+        });
+        if (drivers.length >= PER_TYPE_RESULTS) break;
+      }
+    }
+
+    const loads: SearchResult[] = [];
+    for (const d of loadsSnap.docs) {
+      const v = d.data() as Record<string, any>;
+      if (has(d.id) || has(v.origin) || has(v.destination) || has(v.cargo) || has(v.description)) {
+        loads.push({
+          id: d.id,
+          label: `${v.origin || '?'} → ${v.destination || '?'}`,
+          sub: v.cargo || '',
+          detail: v.status || '',
+        });
+        if (loads.length >= PER_TYPE_RESULTS) break;
+      }
+    }
+
+    const matches: SearchResult[] = [];
+    for (const d of matchesSnap.docs) {
+      const v = d.data() as Record<string, any>;
+      if (
+        has(d.id) ||
+        has(v.loadOwnerName) || has(v.driverOwnerName) || has(v.driverName) ||
+        has(v.loadSnapshot?.origin) || has(v.loadSnapshot?.destination) ||
+        has(v.loadOwnerId) || has(v.driverOwnerId)
+      ) {
+        matches.push({
+          id: d.id,
+          label: `${v.loadSnapshot?.origin || '?'} → ${v.loadSnapshot?.destination || '?'}`,
+          sub: `${v.loadOwnerName || ''} ↔ ${v.driverOwnerName || ''}`,
+          detail: v.status || '',
+        });
+        if (matches.length >= PER_TYPE_RESULTS) break;
+      }
+    }
+
+    const tlas: SearchResult[] = [];
+    for (const d of tlasSnap.docs) {
+      const v = d.data() as Record<string, any>;
+      if (
+        has(d.id) ||
+        has(v.trip?.origin) || has(v.trip?.destination) ||
+        has(v.lessor?.legalName) || has(v.lessee?.legalName) ||
+        has(v.driver?.name) || has(v.matchId)
+      ) {
+        tlas.push({
+          id: d.id,
+          label: `${v.trip?.origin || '?'} → ${v.trip?.destination || '?'}`,
+          sub: `${v.lessor?.legalName || ''} ↔ ${v.lessee?.legalName || ''}`,
+          detail: v.status || '',
+        });
+        if (tlas.length >= PER_TYPE_RESULTS) break;
+      }
+    }
+
+    return json({ owner_operators, drivers, loads, matches, tlas }, 200);
+  } catch (error: any) {
+    console.error('[GET /api/admin/search]', error);
+    return json({ error: 'Search failed.' }, 500);
+  }
+}
+
+export const GET = withCors(handleGet);


### PR DESCRIPTION
Third chunk of **DEV-166**. Global search across the admin console.

## What ships
- **`GET /api/admin/search?q=…`** — scans `owner_operators`, `drivers` (collectionGroup), `loads` (collectionGroup), `matches`, and `tlas` — up to 500 docs per collection — and substring-matches across the fields admins actually search for (id, email, DOT, company, route, driver name, etc.). Returns up to 10 results per type. Gated on `audit:view`.
- **`/admin/search`** — dedicated results page with its own search input. Results are grouped by type and link into the relevant admin list page.
- **Admin header search bar** + a **Global Search** entry in the sidebar — search is accessible from any page in the console.
- **Deep-link wiring**: every result links to the corresponding admin list page with `?q=<id>`. The 5 admin list pages (`users`, `drivers`, `loads`, `matches`, `tlas`) now read `?q=` on mount and prefill their existing search box, so clicking a search result lands you on the entity already filtered in.

## Test plan
- [ ] Type a term in the header search bar (e.g. a company name or DOT #) → press Enter → land on `/admin/search?q=…` with grouped results
- [ ] Search results show: OOs, drivers, loads, matches, TLAs (whichever match)
- [ ] Click a result → land on the relevant admin list page, with that entity already in the search filter
- [ ] Search with no matches → "No results" card
- [ ] As `support` (audit:view) → search works
- [ ] As `billing_admin` (no audit:view) → endpoint returns 403, page shows "No access"

## Known limits (documented)
- Substring scan, not a real search index. Caps at ~500 docs per collection. Plenty today; upgrade to a search index when data scale demands it.

## Remaining DEV-166
- **Impersonation** — biggest + most security-sensitive piece. Going there next.

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_