### PR TITLE
fix(security): remove publicly-routable debug pages from dashboard (DEV-149)

### DIFF
--- a/src/app/dashboard/debug-simple/page.tsx
+++ b/src/app/dashboard/debug-simple/page.tsx
@@ -1,5 +1,0 @@
-'use client';
-
-export default function DebugSimple() {
-  return <div style={{ padding: '50px', fontSize: '24px' }}>DASHBOARD DEBUG WORKS!</div>;
-}

--- a/src/app/dashboard/debug-test.tsx
+++ b/src/app/dashboard/debug-test.tsx
@@ -1,3 +1,0 @@
-export default function DebugTest() {
-  return <div style={{ padding: '50px', fontSize: '24px' }}>DEBUG TEST PAGE WORKS!</div>;
-}


### PR DESCRIPTION
## Summary
- Deletes `/dashboard/debug-simple` and `/dashboard/debug-test` — leftover debug routes that any authenticated user (and crawlers) could load.
- No references anywhere; trivial removal.

Closes **[DEV-149](https://xtrafleet-team.atlassian.net/browse/DEV-149)**.

## Changes
- `src/app/dashboard/debug-simple/page.tsx` — deleted (returned a static "DASHBOARD DEBUG WORKS!" page)
- `src/app/dashboard/debug-test.tsx` — deleted (same, but a loose `.tsx` file inside the dashboard route)

## Setup Required
None.

## Test plan
- [ ] After deploy, `https://xtrafleet-qa--xtrafleet-qa.us-central1.hosted.app/dashboard/debug-simple` returns 404
- [ ] `https://…/dashboard/debug-test` also 404s
- [ ] Existing dashboard routes load normally

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_

[DEV-149]: https://xtrafleet-team.atlassian.net/browse/DEV-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ