### PR TITLE
feat(tla): insurance attestation guard at trip start + stronger UI signal (DEV-81)

### DIFF
--- a/src/components/tla/TLAAgreementDetails.tsx
+++ b/src/components/tla/TLAAgreementDetails.tsx
@@ -225,12 +225,29 @@ export function TLAAgreementDetails({ tla }: TLAAgreementDetailsProps) {
                   Fleet A confirms that the Driver holds a valid CDL, possesses a current
                   medical certificate, and has a compliant driver qualification file.
                 </p>
-                {tla.insurance?.option && (
-                  <div className="mt-3 p-2 bg-muted rounded">
-                    <p className="font-medium text-foreground">
+                {tla.insurance?.option ? (
+                  <div className="mt-3 rounded border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950/30">
+                    <p className="text-sm font-medium text-green-900 dark:text-green-100">
+                      ✓ Insurance attested
+                    </p>
+                    <p className="mt-1 text-xs text-green-900/80 dark:text-green-100/80">
                       {tla.insurance.option === 'existing_policy'
-                        ? '☑ Lessee confirms existing insurance policy covers this trip'
-                        : '☑ Lessee elected trip-based coverage'}
+                        ? 'Lessee confirms existing insurance policy covers this trip.'
+                        : 'Lessee elected trip-based coverage.'}
+                    </p>
+                    {tla.insurance.confirmedAt && (
+                      <p className="mt-1 text-xs text-green-900/70 dark:text-green-100/70">
+                        Recorded {formatTLADate(tla.insurance.confirmedAt)}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="mt-3 rounded border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950/30">
+                    <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                      ⚠ Insurance attestation pending
+                    </p>
+                    <p className="mt-1 text-xs text-amber-900/80 dark:text-amber-100/80">
+                      The lessee must confirm an insurance option during signing before the trip can start.
                     </p>
                   </div>
                 )}

--- a/src/lib/tla-actions.ts
+++ b/src/lib/tla-actions.ts
@@ -237,7 +237,15 @@ export async function signTLA(params: SignTLAParams): Promise<TLA | null> {
  */
 export async function startTrip(params: TripActionParams): Promise<TLA | null> {
   const { firestore, tlaId, tla, userId, userName } = params;
-  
+
+  // DEV-81: insurance attestation must be on file before a trip can start.
+  // The sign flow already requires the lessee to pick an insurance option,
+  // so this is defense in depth against records created by other paths.
+  if (!tla.insurance?.option) {
+    showError("Trip cannot start: insurance attestation is missing.");
+    return null;
+  }
+
   try {
     const now = new Date().toISOString();
     


### PR DESCRIPTION
## Summary
- Adds a defensive insurance-attestation guard to `startTrip()` so a TLA cannot transition to `in_progress` without `insurance.option` on file.
- Replaces the buried, fine-print insurance line in the agreement-details card with a prominent green ✓ "Insurance attested" card (or amber "pending" fallback) that includes the confirmation timestamp.

Closes **[DEV-81](https://xtrafleet-team.atlassian.net/browse/DEV-81)**.

### Why not the field-rename the ticket proposes
The ticket suggests `insuranceAttested` / `insuranceAttestedAt` / `insuranceAttestedBy`, but the TLA schema has shipped with the functionally-equivalent `insurance.{option, confirmedAt, confirmedBy}` for some time. The sign flow already requires the lessee to pick an option before completing a signature, so the attestation capture is in place. Renaming the fields would require a data migration with no behavioral change — keeping the existing names.

## Changes
- `src/lib/tla-actions.ts` — `startTrip()` now returns early with a "Trip cannot start: insurance attestation is missing" toast when `tla.insurance?.option` is falsy. Caller in `TLATripControls.tsx` already handles a `null` return cleanly.
- `src/components/tla/TLAAgreementDetails.tsx` — Insurance section now renders a clearly-labeled attested/pending status block with timestamp.

## Setup Required
None.

## Test plan
- [ ] Sign a TLA as lessee on QA → confirm the agreement-details card shows a green "✓ Insurance attested" card with the chosen option and a timestamp under the **Insurance & Liability** heading.
- [ ] As admin on `/admin/tlas`, edit a signed TLA and clear `insurance.option`. Try **Start Trip** as the lessor — confirm the toast "Trip cannot start: insurance attestation is missing." appears and the TLA stays in `signed`.
- [ ] Re-set `insurance.option` from admin → **Start Trip** works normally.
- [ ] In the agreement card on a TLA missing `insurance.option`, confirm the amber "⚠ Insurance attestation pending" card renders.
- [ ] Build & Playwright checks remain green.

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_

[DEV-81]: https://xtrafleet-team.atlassian.net/browse/DEV-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ