### PR TITLE
fix(rules): tighten matches/tlas update/delete to parties or admins (DEV-95)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -105,20 +105,38 @@ service cloud.firestore {
     }
 
     // Matches collection
+    // DEV-95: tighten to require the caller is a party to the match (load
+    // owner, driver owner, or the driver themselves), or an admin. Match
+    // *formation* happens server-side via /api/matches/accept (DEV-162) and
+    // bypasses these rules entirely via the Admin SDK — these rules only
+    // constrain direct client writes (e.g. rejecting an offer, cancelling).
     match /matches/{matchId} {
       allow read: if isSignedIn();
       allow create: if isSignedIn();
-      allow update: if isSignedIn();
-      allow delete: if isSignedIn();
+      allow update: if isSignedIn() && (
+        resource.data.loadOwnerId == request.auth.uid ||
+        resource.data.driverOwnerId == request.auth.uid ||
+        resource.data.driverId == request.auth.uid ||
+        isAdmin()
+      );
+      allow delete: if isSignedIn() && (
+        resource.data.loadOwnerId == request.auth.uid ||
+        isSuperAdmin()
+      );
     }
 
     // TLAs collection
+    // Creation is server-only (/api/matches/accept) so the synchronous
+    // compliance gate cannot be bypassed (DEV-162). DEV-95: lock updates
+    // to TLA parties or admins — was over-permissive before.
     match /tlas/{tlaId} {
       allow read: if isSignedIn();
-      // TLAs are created only server-side (/api/matches/accept) so the
-      // synchronous compliance gate cannot be bypassed (DEV-162).
       allow create: if false;
-      allow update: if isSignedIn();
+      allow update: if isSignedIn() && (
+        resource.data.lessor.ownerOperatorId == request.auth.uid ||
+        resource.data.lessee.ownerOperatorId == request.auth.uid ||
+        isAdmin()
+      );
       allow delete: if isSignedIn() && isSuperAdmin();
     }
 


### PR DESCRIPTION
## Summary
Tightens two over-permissive Firestore rules that allowed any signed-in user to mutate any other user's match or TLA.

- **`matches.update`** — now requires `loadOwnerId`, `driverOwnerId`, `driverId`, or admin
- **`matches.delete`** — narrows further to `loadOwnerId` or super_admin
- **`tlas.update`** — now requires `lessor.ownerOperatorId`, `lessee.ownerOperatorId`, or admin

Closes [DEV-95](https://xtrafleet-team.atlassian.net/browse/DEV-95).

## Why now
DEV-162 already locked TLA creation to the server (so the patent-critical compliance gate cannot be bypassed) and removed the loads `Matched` escape hatch. The `update` side was still loose — that meant a signed-in attacker could, for example, mark someone else's match as `accepted` or flip a stranger's TLA to `voided`. This closes that gap before the production rules deploy in DEV-163.

## Safety analysis (client-side writers audited)
All client writes are already done by a legitimate party — no behavior change:

| Writer | Party |
|---|---|
| `signTLA()` (`tla-actions.ts:163`) | lessor or lessee |
| `startTrip()`, `endTrip()` | lessor (driver owner) |
| `match-response-modal` counter/decline | loadOwnerId |
| `sent-requests` cancel | driverOwnerId |
| `requests` counter-decline | loadOwnerId |

Server-side flows (`/api/matches/accept`, admin edits) bypass these rules via the Admin SDK — unchanged.

## Setup Required
None beyond the existing DEV-163 reminder: **production Firestore rules must be redeployed when this lands on `main`**. QA rules deploy is unchanged (already gated through the same path).

## Test plan
- [ ] As Owner A (load owner): post a load, receive a request from Owner B, decline it → match transitions to `declined`. Audit shows `match_cancelled` or similar.
- [ ] As Owner A: post a load, receive request from Owner B, send a counter → match status updates with counter terms.
- [ ] As Owner B (driver owner): cancel a sent request → match flips to `cancelled`.
- [ ] As lessor: sign a TLA → succeeds, status updates.
- [ ] As lessee: sign a TLA → succeeds, insurance.option saved.
- [ ] As lessor: start trip → succeeds.
- [ ] Negative test from browser console while signed in as Owner C: `updateDoc(doc(db,'matches','{matchIdForA}'), {status:'declined'})` → permission denied.
- [ ] Negative test: `updateDoc(doc(db,'tlas','{tlaIdForA}'), {status:'voided'})` from Owner C → permission denied.
- [ ] Admin edits from `/admin/tlas` and `/admin/matches` still work (Admin SDK bypasses rules, so this is a smoke test only).

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_

[DEV-95]: https://xtrafleet-team.atlassian.net/browse/DEV-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ