### PR TITLE
ux: dashboard polish batch (DEV-138, 141, 142, 146, 147, 148)

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -18,7 +18,7 @@ import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { HelpWidget } from "@/components/help-widget";
 import { OnboardingBanner } from "@/components/onboarding-banner";
-import { Home, Users, Truck, Settings, LifeBuoy, BarChart, LogOut, Loader2, FileText, HelpCircle, Shield, MessageSquare, User, ChevronDown, ArrowLeftRight } from "lucide-react";
+import { Home, Users, Truck, Settings, LifeBuoy, BarChart, LogOut, Loader2, FileText, Shield, MessageSquare, User, ChevronDown, ArrowLeftRight, CreditCard } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { useUnreadMessagesCount } from "@/hooks/use-unread-messages";
 import { ImpersonationBanner } from "@/components/impersonation-banner";
@@ -66,8 +66,8 @@ function SidebarNav({ onSignOutClick, isAdmin }: { onSignOutClick: () => void; i
         <SidebarMenu>
           <SidebarMenuItem><SidebarNavLink href="/dashboard/profile" tooltip="Profile"><User /><span>Profile</span></SidebarNavLink></SidebarMenuItem>
           <SidebarMenuItem><SidebarNavLink href="/dashboard/settings" tooltip="Settings"><Settings /><span>Settings</span></SidebarNavLink></SidebarMenuItem>
-          <SidebarMenuItem><SidebarNavLink href="/dashboard/billing" tooltip="Billing"><LifeBuoy /><span>Billing & Support</span></SidebarNavLink></SidebarMenuItem>
-          <SidebarMenuItem><SidebarNavLink href="/dashboard/contact" tooltip="Contact Us"><HelpCircle /><span>Contact Us</span></SidebarNavLink></SidebarMenuItem>
+          <SidebarMenuItem><SidebarNavLink href="/dashboard/billing" tooltip="Billing"><CreditCard /><span>Billing & Support</span></SidebarNavLink></SidebarMenuItem>
+          <SidebarMenuItem><SidebarNavLink href="/dashboard/contact" tooltip="Contact Us"><LifeBuoy /><span>Contact Us</span></SidebarNavLink></SidebarMenuItem>
           <SidebarMenuItem><SidebarMenuButton onClick={handleSignOutClick} tooltip="Logout"><LogOut /><span>Logout</span></SidebarMenuButton></SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/src/app/dashboard/loads/page.tsx
+++ b/src/app/dashboard/loads/page.tsx
@@ -120,8 +120,8 @@ export default function LoadsPage() {
   const statusCounts = loads.reduce((acc, l) => { const s = (l.status || 'live') as string; acc[s] = (acc[s] || 0) + 1; return acc; }, {} as Record<string, number>);
 
   return (
-    <div className="container py-8">
-      <div className="flex items-center justify-between mb-6">
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold font-headline">Freight Loads</h1>
           <p className="text-muted-foreground mt-1">Manage your posted freight loads and track their status</p>
@@ -181,7 +181,7 @@ export default function LoadsPage() {
                   const compensation = load.driverCompensation || load.price || 0;
                   const loadType = load.loadType || load.cargo || '';
                   return (
-                    <TableRow key={load.id} className="cursor-pointer hover:bg-muted/50" onClick={() => router.push(`/dashboard/loads/${load.id}/edit`)}>
+                    <TableRow key={load.id} className="hover:bg-muted/50">
                       <TableCell>
                         <div className="font-medium">{load.origin}</div>
                         <div className="text-sm text-muted-foreground">{`\u2192 ${load.destination}`}</div>
@@ -192,7 +192,7 @@ export default function LoadsPage() {
                       <TableCell className="text-right font-medium">{compensation > 0 ? `$${compensation.toLocaleString()}` : 'N/A'}</TableCell>
                       <TableCell><Badge variant={getStatusBadgeVariant(status)}>{getStatusLabel(status)}</Badge></TableCell>
                       <TableCell className="text-right">
-                        <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+                        <div className="flex items-center justify-end gap-1">
                           {editable && <Button variant="ghost" size="sm" onClick={() => router.push(`/dashboard/loads/${load.id}/edit`)}><Edit className="h-4 w-4" /></Button>}
                           {deletable && <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive" onClick={() => setDeleteTarget(load)}>{status === 'draft' ? <Trash2 className="h-4 w-4" /> : <XCircle className="h-4 w-4" />}</Button>}
                         </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -37,7 +37,6 @@ import { ActiveAgreementsWidget } from '@/components/active-agreements-widget';
 import { NotificationsBanner } from '@/components/notifications-banner';
 import { useOnlineStatus } from '@/hooks/use-online-status';
 import { QuickActionsWidget } from '@/components/quick-actions-widget';
-import { TrendIndicator } from '@/components/ui/trend-indicator';
 import { OnboardingChecklist } from '@/components/onboarding-checklist';
 import { GuidedTour, type TourStep } from '@/components/guided-tour';
 import { 
@@ -306,14 +305,11 @@ export default function Dashboard() {
             <Wallet className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="flex items-end justify-between">
-              <div>
-                <div className="text-2xl font-bold">$0.00</div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  No revenue this month
-                </p>
-              </div>
-              <TrendIndicator value={0} label="vs last month" />
+            <div>
+              <div className="text-2xl font-bold">$0.00</div>
+              <p className="text-xs text-muted-foreground mt-1">
+                No revenue this month
+              </p>
             </div>
           </CardContent>
         </Card>
@@ -328,19 +324,11 @@ export default function Dashboard() {
             {driversError ? (
               <span className="text-red-500 text-sm">Error loading data</span>
             ) : (
-              <div className="flex items-end justify-between">
-                <div>
-                  <div className="text-2xl font-bold">+{availableDriversCount}</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Ready for dispatch
-                  </p>
-                </div>
-                {availableDriversCount > 0 && (
-                  <TrendIndicator 
-                    value={availableDriversCount >= 5 ? 12 : availableDriversCount >= 2 ? 25 : 0} 
-                    label="vs last month" 
-                  />
-                )}
+              <div>
+                <div className="text-2xl font-bold">{availableDriversCount}</div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Ready for dispatch
+                </p>
               </div>
             )}
           </CardContent>
@@ -354,19 +342,11 @@ export default function Dashboard() {
             {loadsError ? (
               <span className="text-red-500 text-sm">Error loading data</span>
             ) : (
-              <div className="flex items-end justify-between">
-                <div>
-                  <div className="text-2xl font-bold">+{pendingLoadsCount}</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Waiting for drivers
-                  </p>
-                </div>
-                {pendingLoadsCount > 0 && (
-                  <TrendIndicator 
-                    value={pendingLoadsCount >= 5 ? -8 : pendingLoadsCount >= 2 ? 15 : 0} 
-                    label="vs last month" 
-                  />
-                )}
+              <div>
+                <div className="text-2xl font-bold">{pendingLoadsCount}</div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Waiting for drivers
+                </p>
               </div>
             )}
           </CardContent>
@@ -377,19 +357,11 @@ export default function Dashboard() {
             <Activity className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="flex items-end justify-between">
-              <div>
-                <div className="text-2xl font-bold">+{matchesThisMonth}</div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {matchesThisMonth === 0 ? 'No matches yet' : `${matchesThisMonth} match${matchesThisMonth > 1 ? 'es' : ''} created`}
-                </p>
-              </div>
-              {matchesThisMonth > 0 && (
-                <TrendIndicator 
-                  value={matchesThisMonth >= 10 ? 45 : matchesThisMonth >= 5 ? 20 : 0} 
-                  label="vs last month" 
-                />
-              )}
+            <div>
+              <div className="text-2xl font-bold">{matchesThisMonth}</div>
+              <p className="text-xs text-muted-foreground mt-1">
+                {matchesThisMonth === 0 ? 'No matches yet' : `${matchesThisMonth} match${matchesThisMonth > 1 ? 'es' : ''} created`}
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/src/app/dashboard/requests/page.tsx
+++ b/src/app/dashboard/requests/page.tsx
@@ -288,7 +288,9 @@ export default function RequestsPage() {
       if (complianceWarning && complianceMessage) showInfo(complianceMessage);
       showInfo("You can now message the driver owner.");
       setCounterModalOpen(false);
-      setTimeout(() => { router.push(`/dashboard/tla/${tlaId}`); }, 800);
+      // DEV-141: navigate immediately instead of via a delayed setTimeout that
+      // can fire after the user has already navigated away.
+      router.push(`/dashboard/tla/${tlaId}`);
     } catch (error: any) { console.error("Error accepting counter:", error); showError(error.message || "Failed to accept counter offer."); } finally { setIsAccepting(false); }
   };
 
@@ -304,7 +306,10 @@ export default function RequestsPage() {
     } catch (error: any) { console.error("Error declining counter:", error); showError(error.message || "Failed to decline counter offer."); } finally { setIsDeclining(false); }
   };
 
-  const isLoading = activeTab === "incoming" ? incomingLoading : sentLoading;
+  // DEV-148: both queries fire on mount; if we gate solely on the active
+  // tab's loading flag, the inactive tab's badge can render `0` and look
+  // like there's nothing there. Wait for both before showing badges.
+  const isLoading = incomingLoading || sentLoading;
   if (isLoading) return (<div className="space-y-6"><div><h1 className="text-2xl font-bold font-headline">Match Requests</h1><p className="text-muted-foreground">Loading...</p></div><div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">{[1,2,3].map(i => (<Card key={i}><CardHeader><Skeleton className="h-6 w-48" /><Skeleton className="h-4 w-32" /></CardHeader><CardContent><Skeleton className="h-20 w-full" /></CardContent></Card>))}</div></div>);
 
   return (


### PR DESCRIPTION
## Summary
Six small independent UX cleanups from the Feb 2026 triage list, bundled into one PR since each touches a different file/concern and reviewing them separately would be more friction than value.

| Ticket | File | Fix |
|---|---|---|
| [DEV-138](https://xtrafleet-team.atlassian.net/browse/DEV-138) | `dashboard/layout.tsx` | Sidebar icons: Billing & Support → `CreditCard`; Contact Us → `LifeBuoy` |
| [DEV-141](https://xtrafleet-team.atlassian.net/browse/DEV-141) | `dashboard/requests/page.tsx` | Remove the 800 ms `setTimeout(router.push, …)` leak after counter-offer accept |
| [DEV-142](https://xtrafleet-team.atlassian.net/browse/DEV-142) | `dashboard/loads/page.tsx` | Drop the extra `container py-8` wrapper so padding matches every other dashboard page |
| [DEV-146](https://xtrafleet-team.atlassian.net/browse/DEV-146) | `dashboard/page.tsx` | Remove all four hardcoded fake-trend indicators on the dashboard stat cards |
| [DEV-147](https://xtrafleet-team.atlassian.net/browse/DEV-147) | `dashboard/loads/page.tsx` | Remove row-click → edit (and the `stopPropagation` workaround); explicit action buttons remain |
| [DEV-148](https://xtrafleet-team.atlassian.net/browse/DEV-148) | `dashboard/requests/page.tsx` | Show the loading skeleton until **both** incoming and sent queries resolve, so the Sent tab badge can't flash `0` during fetch |

## Setup Required
None.

## Test plan
- [ ] Sidebar: Billing & Support now shows a credit-card icon; Contact Us now shows a life-buoy icon. Existing flows unchanged.
- [ ] Loads page padding matches the rest of the dashboard (no extra inset).
- [ ] Click anywhere on a load row → nothing happens. Only the explicit Edit / Cancel buttons act.
- [ ] Counter-offer accept from `/dashboard/requests` → navigates to TLA immediately; no delayed push if you click around fast.
- [ ] On `/dashboard/requests` first load, neither tab badge displays `0` while loading — skeleton/loading state shown until both queries finish.
- [ ] Dashboard cards: no `+45%` / `+25%` / `+12%` chips on Available Drivers / Pending Loads / Matches this Month / Total Revenue cards. Counts render as plain numbers.
- [ ] Build + Playwright + Vitest checks all green.

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_

[DEV-138]: https://xtrafleet-team.atlassian.net/browse/DEV-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-141]: https://xtrafleet-team.atlassian.net/browse/DEV-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-142]: https://xtrafleet-team.atlassian.net/browse/DEV-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-146]: https://xtrafleet-team.atlassian.net/browse/DEV-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-147]: https://xtrafleet-team.atlassian.net/browse/DEV-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-148]: https://xtrafleet-team.atlassian.net/browse/DEV-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ