### PR TITLE
fix(admin/drivers): replace free-text Compliance Status inputs with selects

### DIFF
--- a/src/app/admin/drivers/page.tsx
+++ b/src/app/admin/drivers/page.tsx
@@ -814,15 +814,44 @@ export default function AdminDriversPage() {
                 <div className="grid grid-cols-3 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="edit-clearinghouse">Clearinghouse</Label>
-                    <Input id="edit-clearinghouse" value={editForm.clearinghouseStatus} onChange={(e) => setEditForm(f => ({ ...f, clearinghouseStatus: e.target.value }))} />
+                    <Select value={editForm.clearinghouseStatus || '__unset'} onValueChange={(val) => setEditForm(f => ({ ...f, clearinghouseStatus: val === '__unset' ? '' : val }))}>
+                      <SelectTrigger id="edit-clearinghouse"><SelectValue placeholder="Select" /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__unset">— Not set —</SelectItem>
+                        <SelectItem value="compliant">Compliant</SelectItem>
+                        <SelectItem value="pending_query">Pending query</SelectItem>
+                        <SelectItem value="prohibited">Prohibited</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-dqf">DQF Status</Label>
-                    <Input id="edit-dqf" value={editForm.dqfStatus} onChange={(e) => setEditForm(f => ({ ...f, dqfStatus: e.target.value }))} />
+                    <Select value={editForm.dqfStatus || '__unset'} onValueChange={(val) => setEditForm(f => ({ ...f, dqfStatus: val === '__unset' ? '' : val }))}>
+                      <SelectTrigger id="edit-dqf"><SelectValue placeholder="Select" /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__unset">— Not set —</SelectItem>
+                        <SelectItem value="not_required">Not required</SelectItem>
+                        <SelectItem value="pending">Pending</SelectItem>
+                        <SelectItem value="submitted">Submitted</SelectItem>
+                        <SelectItem value="approved">Approved</SelectItem>
+                        <SelectItem value="rejected">Rejected</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-profile-status">Profile Status</Label>
-                    <Input id="edit-profile-status" value={editForm.profileStatus} onChange={(e) => setEditForm(f => ({ ...f, profileStatus: e.target.value }))} />
+                    <Select value={editForm.profileStatus || '__unset'} onValueChange={(val) => setEditForm(f => ({ ...f, profileStatus: val === '__unset' ? '' : val }))}>
+                      <SelectTrigger id="edit-profile-status"><SelectValue placeholder="Select" /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__unset">— Not set —</SelectItem>
+                        <SelectItem value="incomplete">Incomplete</SelectItem>
+                        <SelectItem value="pending_confirmation">Pending confirmation</SelectItem>
+                        <SelectItem value="confirmed">Confirmed</SelectItem>
+                        <SelectItem value="complete">Complete</SelectItem>
+                        <SelectItem value="rejected">Rejected</SelectItem>
+                        <SelectItem value="self_driver">Self driver</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
The Compliance Status section in `/admin/drivers` → Edit Driver was three free-text `<Input>` fields. Support could typo a value (`"Confirmed"` capitalized, trailing whitespace, etc.) and silently render a driver ineligible since the rest of the app key-compares against the exact canonical strings. Replaces all three with `<Select>` dropdowns.

Surfaced while diagnosing a driver who was stuck Red.

## Changes
- **Clearinghouse**: `compliant` / `pending_query` / `prohibited`
- **DQF Status**: `not_required` / `pending` / `submitted` / `approved` / `rejected`
- **Profile Status**: `incomplete` / `pending_confirmation` / `confirmed` / `complete` / `rejected` / `self_driver`

Each select also has a `— Not set —` option that maps to an empty string on save so admins can clear the field without typing.

## Setup Required
None.

## Test plan
- [ ] `/admin/drivers` → Edit Driver → Compliance Status section shows three dropdowns instead of text boxes.
- [ ] Each dropdown shows the canonical options listed above.
- [ ] Selecting `— Not set —` and saving clears the field on the driver doc.
- [ ] Editing a driver who already has a non-canonical value (e.g. legacy `"Confirmed"` with a capital C) shows blank/placeholder and lets you pick the right canonical value.
- [ ] Saving the picked value persists; reopening shows the same selection.

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_