### PR TITLE
feat(admin): create drivers + post loads on behalf of any user (DEV-170)

### DIFF
--- a/src/app/admin/drivers/page.tsx
+++ b/src/app/admin/drivers/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { AddDriverDialog } from '@/components/admin/add-driver-dialog';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -78,7 +80,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useFirestore, useUser } from '@/firebase';
 import { collection, collectionGroup, getDocs, doc, getDoc, updateDoc, deleteDoc } from 'firebase/firestore';
-import { Search, MoreHorizontal, Truck, Eye, RefreshCw, ShieldCheck, Building2, Download, Edit2, Trash2, Loader2 } from 'lucide-react';
+import { Search, MoreHorizontal, Truck, Eye, RefreshCw, ShieldCheck, Building2, Download, Edit2, Trash2, Loader2, PlusCircle } from 'lucide-react';
 import { getComplianceStatus, ComplianceStatus } from '@/lib/compliance';
 import type { Driver } from '@/lib/data';
 import { logAuditAction } from '@/lib/audit';
@@ -187,6 +189,15 @@ export default function AdminDriversPage() {
 
   const canEdit = hasPermission('drivers:edit');
   const canDelete = hasPermission('drivers:delete');
+
+  // DEV-170: Add-Driver dialog. Auto-opens when /admin/drivers is loaded
+  // with ?addFor={ownerOperatorId} (deep link from /admin/onboard).
+  const searchParams = useSearchParams();
+  const addForParam = searchParams?.get('addFor') || '';
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  useEffect(() => {
+    if (addForParam) setAddDialogOpen(true);
+  }, [addForParam]);
 
   const fetchDrivers = async () => {
     if (!firestore) return;
@@ -504,6 +515,11 @@ export default function AdminDriversPage() {
           <Button variant="outline" onClick={handleExport} disabled={filteredDrivers.length === 0}>
             <Download className="h-4 w-4 mr-2" />Export
           </Button>
+          {canEdit && (
+            <Button onClick={() => setAddDialogOpen(true)}>
+              <PlusCircle className="h-4 w-4 mr-2" />Add Driver
+            </Button>
+          )}
           <Button variant="outline" onClick={fetchDrivers} disabled={isLoading}>
             <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />Refresh
           </Button>
@@ -939,6 +955,14 @@ export default function AdminDriversPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* DEV-170: Add Driver dialog */}
+      <AddDriverDialog
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        onSuccess={fetchDrivers}
+        initialOwnerOperatorId={addForParam}
+      />
     </div>
   );
 }

--- a/src/app/admin/loads/page.tsx
+++ b/src/app/admin/loads/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { AddLoadDialog } from '@/components/admin/add-load-dialog';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -52,7 +54,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useFirestore, useUser } from '@/firebase';
 import { collectionGroup, getDocs, doc, getDoc, deleteDoc, updateDoc } from 'firebase/firestore';
-import { Search, Package, RefreshCw, ArrowRight, Building2, Download, Trash2, Loader2, Edit2, MoreHorizontal, Eye } from 'lucide-react';
+import { Search, Package, RefreshCw, ArrowRight, Building2, Download, Trash2, Loader2, Edit2, MoreHorizontal, Eye, PlusCircle } from 'lucide-react';
 import { showSuccess, showError } from '@/lib/toast-utils';
 import { useAdminRole } from '../layout';
 import { format, formatDistanceToNow } from 'date-fns';
@@ -107,6 +109,15 @@ export default function AdminLoadsPage() {
 
   const canDelete = hasPermission('loads:delete');
   const canEdit = hasPermission('loads:edit');
+
+  // DEV-170: Post-Load dialog. Auto-opens when /admin/loads is loaded with
+  // ?addFor={ownerOperatorId} (deep link from /admin/onboard).
+  const searchParams = useSearchParams();
+  const addForParam = searchParams?.get('addFor') || '';
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  useEffect(() => {
+    if (addForParam) setAddDialogOpen(true);
+  }, [addForParam]);
 
   const fetchLoads = async () => {
     if (!firestore) return;
@@ -381,6 +392,11 @@ export default function AdminLoadsPage() {
           <Button variant="outline" onClick={handleExport} disabled={filteredLoads.length === 0}>
             <Download className="h-4 w-4 mr-2" />Export CSV
           </Button>
+          {canEdit && (
+            <Button onClick={() => setAddDialogOpen(true)}>
+              <PlusCircle className="h-4 w-4 mr-2" />Post Load
+            </Button>
+          )}
           <Button variant="outline" onClick={fetchLoads} disabled={isLoading}>
             <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />Refresh
           </Button>
@@ -624,6 +640,14 @@ export default function AdminLoadsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* DEV-170: Post Load dialog */}
+      <AddLoadDialog
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        onSuccess={fetchLoads}
+        initialOwnerOperatorId={addForParam}
+      />
     </div>
   );
 }

--- a/src/app/admin/onboard/page.tsx
+++ b/src/app/admin/onboard/page.tsx
@@ -12,7 +12,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Loader2, UserPlus, Copy, CheckCircle2, Search } from 'lucide-react';
+import { Loader2, UserPlus, Copy, CheckCircle2, Search, Users, Truck } from 'lucide-react';
+import Link from 'next/link';
 import { showSuccess, showError } from '@/lib/toast-utils';
 import { useAdminRole } from '../layout';
 
@@ -200,6 +201,30 @@ export default function AdminOnboardPage() {
                 <Input readOnly value={result.activationUrl} className="font-mono text-xs" />
                 <Button type="button" variant="outline" onClick={copyLink}>
                   <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+            <div className="space-y-2 rounded-lg border border-dashed p-3">
+              <p className="text-sm font-medium">Next: complete the white-glove setup</p>
+              <p className="text-xs text-muted-foreground">
+                Pre-populate this customer's drivers and loads so the activation lands on a
+                lived-in dashboard with a real match waiting.
+              </p>
+              <div className="flex flex-wrap gap-2 pt-1">
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/admin/drivers?addFor=${result.ownerOperatorId}`}>
+                    <Users className="h-4 w-4 mr-1.5" /> Add drivers
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/admin/loads?addFor=${result.ownerOperatorId}`}>
+                    <Truck className="h-4 w-4 mr-1.5" /> Post loads
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/admin/matches?q=${result.ownerOperatorId}`}>
+                    Form a match
+                  </Link>
                 </Button>
               </div>
             </div>

--- a/src/app/api/admin/drivers/route.ts
+++ b/src/app/api/admin/drivers/route.ts
@@ -1,0 +1,175 @@
+/**
+ * Admin: create a driver on behalf of an owner-operator (DEV-170).
+ *
+ * Completes the white-glove onboarding loop. After pre-registering a fleet
+ * via /admin/onboard, the white-glove team uses this endpoint to populate
+ * that fleet's drivers so a real compliance-verified match can be formed
+ * on their behalf before they ever activate.
+ *
+ * Gating: `drivers:edit` permission (same as the edit flow). Target
+ * owner-operator must exist; can be pre-activated or active.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+const bodySchema = z.object({
+  ownerOperatorId: z.string().trim().min(1, 'ownerOperatorId is required'),
+  // Required identity
+  name: z.string().trim().min(1, 'Driver name is required'),
+  email: z.string().trim().email().optional().or(z.literal('')),
+  phoneNumber: z.string().trim().optional(),
+  location: z.string().trim().optional(),
+  vehicleType: z.string().trim().optional(),
+  availability: z.string().trim().optional(),
+  trailerTypes: z.array(z.string()).optional(),
+  // CDL
+  cdlLicense: z.string().trim().optional(),
+  cdlState: z.string().trim().optional(),
+  cdlClass: z.string().trim().optional(),
+  cdlExpiry: z.string().trim().optional(),
+  cdlLicenseUrl: z.string().trim().optional(),
+  cdlDocumentUrl: z.string().trim().optional(),
+  endorsements: z.string().trim().optional(),
+  // Medical + insurance
+  medicalCardExpiry: z.string().trim().optional(),
+  medicalCardUrl: z.string().trim().optional(),
+  insuranceExpiry: z.string().trim().optional(),
+  insuranceUrl: z.string().trim().optional(),
+  insurerName: z.string().trim().optional(),
+  insurancePolicyNumber: z.string().trim().optional(),
+  // MVR + screenings
+  motorVehicleRecordNumber: z.string().trim().optional(),
+  mvrUrl: z.string().trim().optional(),
+  backgroundCheckDate: z.string().trim().optional(),
+  backgroundCheckUrl: z.string().trim().optional(),
+  preEmploymentScreeningDate: z.string().trim().optional(),
+  preEmploymentScreeningUrl: z.string().trim().optional(),
+  drugAndAlcoholScreeningDate: z.string().trim().optional(),
+  drugAndAlcoholScreeningUrl: z.string().trim().optional(),
+  // Compliance status (DEV-167 dropdown values)
+  clearinghouseStatus: z.string().trim().optional(),
+  dqfStatus: z.string().trim().optional(),
+  profileStatus: z.string().trim().optional(),
+  // Eligibility flag
+  isActive: z.boolean().optional(),
+});
+
+async function handlePost(request: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+
+    // 1. Authenticate.
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+    const adminEmail = decoded.email || '';
+
+    // 2. Authorize — drivers:edit.
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'drivers:edit')) {
+      return json({ error: 'You do not have permission to add drivers.' }, 403);
+    }
+
+    // 3. Validate input.
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return json({ error: 'Invalid request body.' }, 400);
+    }
+    const parsed = bodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return json(
+        {
+          error:
+            Object.values(parsed.error.flatten().fieldErrors).flat().join(', ') ||
+            'Invalid input.',
+        },
+        400
+      );
+    }
+    const input = parsed.data;
+
+    // 4. Confirm the target owner-operator exists.
+    const ownerSnap = await db.collection('owner_operators').doc(input.ownerOperatorId).get();
+    if (!ownerSnap.exists) {
+      return json({ error: 'Target owner-operator not found.' }, 404);
+    }
+    const ownerData = ownerSnap.data() as { legalName?: string; companyName?: string };
+
+    // 5. Create the driver. Default profileStatus to 'confirmed' for the
+    //    admin-created path (decision recorded on DEV-170): the admin has
+    //    already verified the driver offline.
+    const driverRef = db
+      .collection('owner_operators')
+      .doc(input.ownerOperatorId)
+      .collection('drivers')
+      .doc();
+    const driverId = driverRef.id;
+    const now = new Date().toISOString();
+
+    const { ownerOperatorId, ...rest } = input;
+    const driverDoc: Record<string, unknown> = {
+      id: driverId,
+      ...rest,
+      profileStatus: input.profileStatus || 'confirmed',
+      profileComplete: true,
+      availability: input.availability || 'Available',
+      isActive: input.isActive ?? true,
+      trailerTypes: input.trailerTypes ?? [],
+      createdByAdmin: adminUid,
+      createdAt: now,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+
+    await driverRef.set(driverDoc);
+
+    // 6. Audit.
+    await db.collection('audit_logs').add({
+      action: 'driver_created_by_admin',
+      adminId: adminUid,
+      adminEmail,
+      targetType: 'driver',
+      targetId: driverId,
+      targetName: input.name,
+      details: {
+        ownerOperatorId,
+        ownerName: ownerData.companyName || ownerData.legalName || '',
+      },
+      timestamp: FieldValue.serverTimestamp(),
+      createdAt: now,
+    });
+
+    return json({ success: true, driverId, ownerOperatorId }, 200);
+  } catch (error) {
+    console.error('[POST /api/admin/drivers]', error);
+    return json(
+      { error: 'An unexpected error occurred while creating the driver.' },
+      500
+    );
+  }
+}
+
+export const POST = withCors(handlePost);

--- a/src/app/api/admin/loads/route.ts
+++ b/src/app/api/admin/loads/route.ts
@@ -1,0 +1,143 @@
+/**
+ * Admin: post a load on behalf of an owner-operator (DEV-170).
+ *
+ * Companion to /api/admin/drivers. Lets the white-glove team populate
+ * a pre-registered or active fleet's marketplace presence before that
+ * fleet ever signs in, so a real compliance-verified match can be
+ * formed on their behalf.
+ *
+ * Gating: `loads:edit` permission (same as the edit flow).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getFirebaseAdmin, FieldValue } from '@/lib/firebase-admin-singleton';
+import { withCors } from '@/lib/api-cors';
+import { hasPermission, getDefaultRoleForLegacyAdmin, type AdminRole } from '@/lib/admin-roles';
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, { status });
+}
+
+const bodySchema = z.object({
+  ownerOperatorId: z.string().trim().min(1, 'ownerOperatorId is required'),
+  origin: z.string().trim().min(1, 'Origin is required'),
+  destination: z.string().trim().min(1, 'Destination is required'),
+  cargo: z.string().trim().optional(),
+  loadType: z.string().trim().optional(),
+  weight: z.coerce.number().nonnegative().optional(),
+  status: z.string().trim().optional(),
+  requiredQualifications: z.array(z.string()).optional(),
+  trailerType: z.string().trim().optional(),
+  description: z.string().trim().optional(),
+  price: z.coerce.number().nonnegative().optional(),
+  driverCompensation: z.coerce.number().nonnegative().optional(),
+  pickupDate: z.string().trim().optional(),
+});
+
+async function handlePost(request: NextRequest) {
+  try {
+    const { auth, db } = await getFirebaseAdmin();
+
+    // 1. Authenticate.
+    const tokenCookie = request.cookies.get('fb-id-token');
+    if (!tokenCookie) return json({ error: 'You must be signed in.' }, 401);
+    let decoded: { uid: string; email?: string };
+    try {
+      try {
+        decoded = await auth.verifySessionCookie(tokenCookie.value, true);
+      } catch {
+        decoded = await auth.verifyIdToken(tokenCookie.value);
+      }
+    } catch {
+      return json({ error: 'Your session is invalid. Please sign in again.' }, 401);
+    }
+    const adminUid = decoded.uid;
+    const adminEmail = decoded.email || '';
+
+    // 2. Authorize — loads:edit.
+    const adminSnap = await db.collection('owner_operators').doc(adminUid).get();
+    const adminData = adminSnap.exists ? adminSnap.data() : null;
+    if (!adminData?.isAdmin) {
+      return json({ error: 'Admin access required.' }, 403);
+    }
+    const role: AdminRole = (adminData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin();
+    if (!hasPermission(role, 'loads:edit')) {
+      return json({ error: 'You do not have permission to post loads.' }, 403);
+    }
+
+    // 3. Validate input.
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return json({ error: 'Invalid request body.' }, 400);
+    }
+    const parsed = bodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return json(
+        {
+          error:
+            Object.values(parsed.error.flatten().fieldErrors).flat().join(', ') ||
+            'Invalid input.',
+        },
+        400
+      );
+    }
+    const input = parsed.data;
+
+    // 4. Confirm the target owner-operator exists.
+    const ownerSnap = await db.collection('owner_operators').doc(input.ownerOperatorId).get();
+    if (!ownerSnap.exists) {
+      return json({ error: 'Target owner-operator not found.' }, 404);
+    }
+    const ownerData = ownerSnap.data() as { legalName?: string; companyName?: string };
+
+    // 5. Create the load.
+    const loadRef = db
+      .collection('owner_operators')
+      .doc(input.ownerOperatorId)
+      .collection('loads')
+      .doc();
+    const loadId = loadRef.id;
+    const now = new Date().toISOString();
+
+    const { ownerOperatorId, ...rest } = input;
+    const loadDoc: Record<string, unknown> = {
+      id: loadId,
+      ...rest,
+      status: input.status || 'Pending',
+      requiredQualifications: input.requiredQualifications ?? [],
+      createdByAdmin: adminUid,
+      createdAt: now,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+
+    await loadRef.set(loadDoc);
+
+    // 6. Audit.
+    await db.collection('audit_logs').add({
+      action: 'load_created_by_admin',
+      adminId: adminUid,
+      adminEmail,
+      targetType: 'load',
+      targetId: loadId,
+      targetName: `${input.origin} → ${input.destination}`,
+      details: {
+        ownerOperatorId,
+        ownerName: ownerData.companyName || ownerData.legalName || '',
+      },
+      timestamp: FieldValue.serverTimestamp(),
+      createdAt: now,
+    });
+
+    return json({ success: true, loadId, ownerOperatorId }, 200);
+  } catch (error) {
+    console.error('[POST /api/admin/loads]', error);
+    return json(
+      { error: 'An unexpected error occurred while creating the load.' },
+      500
+    );
+  }
+}
+
+export const POST = withCors(handlePost);

--- a/src/components/admin/add-driver-dialog.tsx
+++ b/src/components/admin/add-driver-dialog.tsx
@@ -1,0 +1,552 @@
+'use client';
+
+/**
+ * Add Driver dialog — admin creates a driver on behalf of any owner-operator
+ * (DEV-170). Mirrors the customer-side driver creation surface and calls
+ * `POST /api/admin/drivers`. Default `profileStatus` is `confirmed` per the
+ * decision recorded on DEV-170 — admin is expected to have verified offline.
+ */
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { showError, showSuccess } from '@/lib/toast-utils';
+import { OwnerOperatorPicker, type PickerOwnerOperator } from './owner-operator-picker';
+
+interface AddDriverDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+  /** Optional pre-selected owner-operator id (deep link from /admin/onboard). */
+  initialOwnerOperatorId?: string;
+  initialFilter?: string;
+}
+
+const empty = {
+  ownerOperatorId: '',
+  name: '',
+  email: '',
+  phoneNumber: '',
+  location: '',
+  vehicleType: '',
+  availability: 'Available',
+  trailerTypes: '',
+  cdlLicense: '',
+  cdlState: '',
+  cdlClass: '',
+  cdlExpiry: '',
+  cdlLicenseUrl: '',
+  cdlDocumentUrl: '',
+  endorsements: '',
+  medicalCardExpiry: '',
+  medicalCardUrl: '',
+  insuranceExpiry: '',
+  insuranceUrl: '',
+  insurerName: '',
+  insurancePolicyNumber: '',
+  motorVehicleRecordNumber: '',
+  mvrUrl: '',
+  backgroundCheckDate: '',
+  backgroundCheckUrl: '',
+  preEmploymentScreeningDate: '',
+  preEmploymentScreeningUrl: '',
+  drugAndAlcoholScreeningDate: '',
+  drugAndAlcoholScreeningUrl: '',
+  clearinghouseStatus: '',
+  dqfStatus: '',
+  profileStatus: 'confirmed',
+};
+
+type FormState = typeof empty;
+
+export function AddDriverDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+  initialOwnerOperatorId,
+  initialFilter,
+}: AddDriverDialogProps) {
+  const [form, setForm] = useState<FormState>({
+    ...empty,
+    ownerOperatorId: initialOwnerOperatorId || '',
+  });
+  const [saving, setSaving] = useState(false);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function reset() {
+    setForm({ ...empty, ownerOperatorId: initialOwnerOperatorId || '' });
+  }
+
+  async function handleSubmit() {
+    if (!form.ownerOperatorId) {
+      showError('Pick an owner-operator first.');
+      return;
+    }
+    if (!form.name.trim()) {
+      showError('Driver name is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload: Record<string, unknown> = {
+        ...form,
+        trailerTypes: form.trailerTypes
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      };
+      const res = await fetch('/api/admin/drivers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || 'Failed to create driver.');
+      }
+      showSuccess('Driver created.');
+      reset();
+      onOpenChange(false);
+      onSuccess?.();
+    } catch (err: unknown) {
+      showError(err instanceof Error ? err.message : 'Failed to create driver.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!saving) onOpenChange(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogContent className="max-w-2xl max-h-[90vh] p-0 flex flex-col">
+        <DialogHeader className="px-6 pt-6">
+          <DialogTitle>Add Driver</DialogTitle>
+          <DialogDescription>
+            Create a driver on behalf of an owner-operator. Useful for white-glove
+            onboarding before the customer activates.
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="flex-1">
+          <div className="px-6 py-4 space-y-5">
+            <div className="space-y-2">
+              <Label>Owner Operator</Label>
+              <OwnerOperatorPicker
+                value={form.ownerOperatorId}
+                onChange={(id, _owner: PickerOwnerOperator | null) =>
+                  update('ownerOperatorId', id)
+                }
+                disabled={saving}
+                initialFilter={initialFilter}
+              />
+              <p className="text-xs text-muted-foreground">
+                Pick the carrier this driver belongs to. Pre-activated accounts are
+                tagged so you can spot the white-glove fleets.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-name">Name</Label>
+                <Input
+                  id="add-driver-name"
+                  value={form.name}
+                  onChange={(e) => update('name', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-email">Email</Label>
+                <Input
+                  id="add-driver-email"
+                  type="email"
+                  value={form.email}
+                  onChange={(e) => update('email', e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-phone">Phone</Label>
+                <Input
+                  id="add-driver-phone"
+                  type="tel"
+                  value={form.phoneNumber}
+                  onChange={(e) => update('phoneNumber', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-location">Location</Label>
+                <Input
+                  id="add-driver-location"
+                  value={form.location}
+                  onChange={(e) => update('location', e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-vehicle">Vehicle Type</Label>
+                <Input
+                  id="add-driver-vehicle"
+                  value={form.vehicleType}
+                  onChange={(e) => update('vehicleType', e.target.value)}
+                  placeholder="Dry Van, Reefer, …"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-trailers">
+                  Trailer Types{' '}
+                  <span className="text-xs text-muted-foreground">(comma-separated)</span>
+                </Label>
+                <Input
+                  id="add-driver-trailers"
+                  value={form.trailerTypes}
+                  onChange={(e) => update('trailerTypes', e.target.value)}
+                  placeholder="dry-van, reefer, flatbed"
+                />
+              </div>
+            </div>
+
+            <div className="pt-3 border-t space-y-3">
+              <p className="text-sm font-medium text-muted-foreground">CDL Details</p>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-cdl">CDL License</Label>
+                  <Input
+                    id="add-driver-cdl"
+                    value={form.cdlLicense}
+                    onChange={(e) => update('cdlLicense', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-cdl-expiry">CDL Expiry</Label>
+                  <Input
+                    id="add-driver-cdl-expiry"
+                    type="date"
+                    value={form.cdlExpiry}
+                    onChange={(e) => update('cdlExpiry', e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-cdl-state">CDL State</Label>
+                  <Input
+                    id="add-driver-cdl-state"
+                    value={form.cdlState}
+                    onChange={(e) => update('cdlState', e.target.value)}
+                    placeholder="e.g. FL"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-cdl-class">CDL Class</Label>
+                  <Input
+                    id="add-driver-cdl-class"
+                    value={form.cdlClass}
+                    onChange={(e) => update('cdlClass', e.target.value)}
+                    placeholder="A, B, or C"
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-endorsements">Endorsements</Label>
+                <Input
+                  id="add-driver-endorsements"
+                  value={form.endorsements}
+                  onChange={(e) => update('endorsements', e.target.value)}
+                  placeholder="H, N, T"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-cdl-license-url">CDL License URL</Label>
+                  <Input
+                    id="add-driver-cdl-license-url"
+                    type="url"
+                    value={form.cdlLicenseUrl}
+                    onChange={(e) => update('cdlLicenseUrl', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-cdl-doc-url">CDL Document URL</Label>
+                  <Input
+                    id="add-driver-cdl-doc-url"
+                    type="url"
+                    value={form.cdlDocumentUrl}
+                    onChange={(e) => update('cdlDocumentUrl', e.target.value)}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="pt-3 border-t space-y-3">
+              <p className="text-sm font-medium text-muted-foreground">
+                Medical &amp; Insurance
+              </p>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-medical-expiry">Medical Card Expiry</Label>
+                  <Input
+                    id="add-driver-medical-expiry"
+                    type="date"
+                    value={form.medicalCardExpiry}
+                    onChange={(e) => update('medicalCardExpiry', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-insurance-expiry">Insurance Expiry</Label>
+                  <Input
+                    id="add-driver-insurance-expiry"
+                    type="date"
+                    value={form.insuranceExpiry}
+                    onChange={(e) => update('insuranceExpiry', e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-medical-url">Medical Card URL</Label>
+                <Input
+                  id="add-driver-medical-url"
+                  type="url"
+                  value={form.medicalCardUrl}
+                  onChange={(e) => update('medicalCardUrl', e.target.value)}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-insurer">Insurer Name</Label>
+                  <Input
+                    id="add-driver-insurer"
+                    value={form.insurerName}
+                    onChange={(e) => update('insurerName', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-policy">Policy Number</Label>
+                  <Input
+                    id="add-driver-policy"
+                    value={form.insurancePolicyNumber}
+                    onChange={(e) => update('insurancePolicyNumber', e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-driver-insurance-url">Insurance URL</Label>
+                <Input
+                  id="add-driver-insurance-url"
+                  type="url"
+                  value={form.insuranceUrl}
+                  onChange={(e) => update('insuranceUrl', e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="pt-3 border-t space-y-3">
+              <p className="text-sm font-medium text-muted-foreground">MVR &amp; Screenings</p>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-mvr">MVR Number</Label>
+                  <Input
+                    id="add-driver-mvr"
+                    value={form.motorVehicleRecordNumber}
+                    onChange={(e) => update('motorVehicleRecordNumber', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-mvr-url">MVR URL</Label>
+                  <Input
+                    id="add-driver-mvr-url"
+                    type="url"
+                    value={form.mvrUrl}
+                    onChange={(e) => update('mvrUrl', e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-bg-date">Background Check Date</Label>
+                  <Input
+                    id="add-driver-bg-date"
+                    type="date"
+                    value={form.backgroundCheckDate}
+                    onChange={(e) => update('backgroundCheckDate', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-bg-url">Background Check URL</Label>
+                  <Input
+                    id="add-driver-bg-url"
+                    type="url"
+                    value={form.backgroundCheckUrl}
+                    onChange={(e) => update('backgroundCheckUrl', e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-pes-date">Pre-Employment Date</Label>
+                  <Input
+                    id="add-driver-pes-date"
+                    type="date"
+                    value={form.preEmploymentScreeningDate}
+                    onChange={(e) =>
+                      update('preEmploymentScreeningDate', e.target.value)
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-pes-url">Pre-Employment URL</Label>
+                  <Input
+                    id="add-driver-pes-url"
+                    type="url"
+                    value={form.preEmploymentScreeningUrl}
+                    onChange={(e) =>
+                      update('preEmploymentScreeningUrl', e.target.value)
+                    }
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-da-date">Drug &amp; Alcohol Date</Label>
+                  <Input
+                    id="add-driver-da-date"
+                    type="date"
+                    value={form.drugAndAlcoholScreeningDate}
+                    onChange={(e) =>
+                      update('drugAndAlcoholScreeningDate', e.target.value)
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-driver-da-url">Drug &amp; Alcohol URL</Label>
+                  <Input
+                    id="add-driver-da-url"
+                    type="url"
+                    value={form.drugAndAlcoholScreeningUrl}
+                    onChange={(e) =>
+                      update('drugAndAlcoholScreeningUrl', e.target.value)
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="pt-3 border-t space-y-3">
+              <p className="text-sm font-medium text-muted-foreground">Compliance Status</p>
+              <div className="grid grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label>Clearinghouse</Label>
+                  <Select
+                    value={form.clearinghouseStatus || '__unset'}
+                    onValueChange={(v) =>
+                      update('clearinghouseStatus', v === '__unset' ? '' : v)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__unset">— Not set —</SelectItem>
+                      <SelectItem value="compliant">Compliant</SelectItem>
+                      <SelectItem value="pending_query">Pending query</SelectItem>
+                      <SelectItem value="prohibited">Prohibited</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>DQF Status</Label>
+                  <Select
+                    value={form.dqfStatus || '__unset'}
+                    onValueChange={(v) => update('dqfStatus', v === '__unset' ? '' : v)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__unset">— Not set —</SelectItem>
+                      <SelectItem value="not_required">Not required</SelectItem>
+                      <SelectItem value="pending">Pending</SelectItem>
+                      <SelectItem value="submitted">Submitted</SelectItem>
+                      <SelectItem value="approved">Approved</SelectItem>
+                      <SelectItem value="rejected">Rejected</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Profile Status</Label>
+                  <Select
+                    value={form.profileStatus || '__unset'}
+                    onValueChange={(v) =>
+                      update('profileStatus', v === '__unset' ? '' : v)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__unset">— Not set —</SelectItem>
+                      <SelectItem value="incomplete">Incomplete</SelectItem>
+                      <SelectItem value="pending_confirmation">
+                        Pending confirmation
+                      </SelectItem>
+                      <SelectItem value="confirmed">Confirmed</SelectItem>
+                      <SelectItem value="complete">Complete</SelectItem>
+                      <SelectItem value="rejected">Rejected</SelectItem>
+                      <SelectItem value="self_driver">Self driver</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Defaults to <code>confirmed</code> on admin-created drivers — assumes you
+                verified the driver offline.
+              </p>
+            </div>
+          </div>
+        </ScrollArea>
+        <DialogFooter className="px-6 pb-6">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Creating…
+              </>
+            ) : (
+              'Create Driver'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/add-load-dialog.tsx
+++ b/src/components/admin/add-load-dialog.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+/**
+ * Post Load dialog — admin creates a load on behalf of any owner-operator
+ * (DEV-170). Calls `POST /api/admin/loads`.
+ */
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { showError, showSuccess } from '@/lib/toast-utils';
+import { OwnerOperatorPicker } from './owner-operator-picker';
+
+interface AddLoadDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+  initialOwnerOperatorId?: string;
+  initialFilter?: string;
+}
+
+const empty = {
+  ownerOperatorId: '',
+  origin: '',
+  destination: '',
+  cargo: '',
+  loadType: '',
+  weight: '',
+  status: 'Pending',
+  requiredQualifications: '',
+  trailerType: '',
+  description: '',
+  price: '',
+  driverCompensation: '',
+  pickupDate: '',
+};
+
+type FormState = typeof empty;
+
+export function AddLoadDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+  initialOwnerOperatorId,
+  initialFilter,
+}: AddLoadDialogProps) {
+  const [form, setForm] = useState<FormState>({
+    ...empty,
+    ownerOperatorId: initialOwnerOperatorId || '',
+  });
+  const [saving, setSaving] = useState(false);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+  function reset() {
+    setForm({ ...empty, ownerOperatorId: initialOwnerOperatorId || '' });
+  }
+
+  async function handleSubmit() {
+    if (!form.ownerOperatorId) {
+      showError('Pick an owner-operator first.');
+      return;
+    }
+    if (!form.origin.trim() || !form.destination.trim()) {
+      showError('Origin and destination are required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload: Record<string, unknown> = {
+        ownerOperatorId: form.ownerOperatorId,
+        origin: form.origin,
+        destination: form.destination,
+        cargo: form.cargo,
+        loadType: form.loadType,
+        weight: form.weight ? Number(form.weight) : undefined,
+        status: form.status,
+        requiredQualifications: form.requiredQualifications
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+        trailerType: form.trailerType,
+        description: form.description,
+        price: form.price ? Number(form.price) : undefined,
+        driverCompensation: form.driverCompensation
+          ? Number(form.driverCompensation)
+          : undefined,
+        pickupDate: form.pickupDate,
+      };
+      const res = await fetch('/api/admin/loads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to post load.');
+      showSuccess('Load posted.');
+      reset();
+      onOpenChange(false);
+      onSuccess?.();
+    } catch (err: unknown) {
+      showError(err instanceof Error ? err.message : 'Failed to post load.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!saving) onOpenChange(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogContent className="max-w-2xl max-h-[90vh] p-0 flex flex-col">
+        <DialogHeader className="px-6 pt-6">
+          <DialogTitle>Post Load</DialogTitle>
+          <DialogDescription>
+            Create a load on behalf of an owner-operator. White-glove flow:
+            pre-register → add drivers → post loads → form a match.
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="flex-1">
+          <div className="px-6 py-4 space-y-5">
+            <div className="space-y-2">
+              <Label>Owner Operator</Label>
+              <OwnerOperatorPicker
+                value={form.ownerOperatorId}
+                onChange={(id) => update('ownerOperatorId', id)}
+                disabled={saving}
+                initialFilter={initialFilter}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="add-load-origin">Origin</Label>
+                <Input
+                  id="add-load-origin"
+                  value={form.origin}
+                  onChange={(e) => update('origin', e.target.value)}
+                  placeholder="City, ST"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-load-destination">Destination</Label>
+                <Input
+                  id="add-load-destination"
+                  value={form.destination}
+                  onChange={(e) => update('destination', e.target.value)}
+                  placeholder="City, ST"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="add-load-cargo">Cargo</Label>
+                <Input
+                  id="add-load-cargo"
+                  value={form.cargo}
+                  onChange={(e) => update('cargo', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-load-type">Load Type</Label>
+                <Input
+                  id="add-load-type"
+                  value={form.loadType}
+                  onChange={(e) => update('loadType', e.target.value)}
+                  placeholder="dry-van, reefer, …"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="add-load-weight">Weight (lbs)</Label>
+                <Input
+                  id="add-load-weight"
+                  type="number"
+                  value={form.weight}
+                  onChange={(e) => update('weight', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-load-price">Price ($)</Label>
+                <Input
+                  id="add-load-price"
+                  type="number"
+                  value={form.price}
+                  onChange={(e) => update('price', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-load-comp">Driver Pay ($)</Label>
+                <Input
+                  id="add-load-comp"
+                  type="number"
+                  value={form.driverCompensation}
+                  onChange={(e) => update('driverCompensation', e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="add-load-trailer">Trailer Type</Label>
+                <Input
+                  id="add-load-trailer"
+                  value={form.trailerType}
+                  onChange={(e) => update('trailerType', e.target.value)}
+                  placeholder="dry-van"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-load-pickup">Pickup Date</Label>
+                <Input
+                  id="add-load-pickup"
+                  type="date"
+                  value={form.pickupDate}
+                  onChange={(e) => update('pickupDate', e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="add-load-quals">
+                Required Qualifications{' '}
+                <span className="text-xs text-muted-foreground">(comma-separated)</span>
+              </Label>
+              <Input
+                id="add-load-quals"
+                value={form.requiredQualifications}
+                onChange={(e) => update('requiredQualifications', e.target.value)}
+                placeholder="cdl-a, hazmat"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="add-load-status">Status</Label>
+              <Select
+                value={form.status}
+                onValueChange={(v) => update('status', v)}
+              >
+                <SelectTrigger id="add-load-status">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Pending">Pending</SelectItem>
+                  <SelectItem value="Matched">Matched</SelectItem>
+                  <SelectItem value="In-transit">In-transit</SelectItem>
+                  <SelectItem value="Delivered">Delivered</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="add-load-description">Description</Label>
+              <Textarea
+                id="add-load-description"
+                value={form.description}
+                onChange={(e) => update('description', e.target.value)}
+                rows={3}
+              />
+            </div>
+          </div>
+        </ScrollArea>
+        <DialogFooter className="px-6 pb-6">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Posting…
+              </>
+            ) : (
+              'Post Load'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/owner-operator-picker.tsx
+++ b/src/components/admin/owner-operator-picker.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+/**
+ * Searchable owner-operator picker for the admin "Add Driver" / "Post Load"
+ * dialogs (DEV-170). Lists pre-activated + active accounts; filters as the
+ * admin types against legalName / companyName / contactEmail / dotNumber.
+ *
+ * Loads all matching accounts on mount via a single Firestore read against
+ * the `owner_operators` collection — admin rules permit this read.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+import { useFirestore } from '@/firebase';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+export interface PickerOwnerOperator {
+  id: string;
+  companyName?: string;
+  legalName?: string;
+  contactEmail?: string;
+  dotNumber?: string;
+  accountStatus?: string;
+}
+
+interface OwnerOperatorPickerProps {
+  value: string;
+  onChange: (id: string, owner: PickerOwnerOperator | null) => void;
+  /** Disable opening the picker (e.g. when the dialog is mid-save). */
+  disabled?: boolean;
+  /** Optional initial filter (deep-link from /admin/onboard for example). */
+  initialFilter?: string;
+}
+
+function displayName(o: PickerOwnerOperator): string {
+  return o.companyName || o.legalName || o.contactEmail || o.id;
+}
+
+function searchHaystack(o: PickerOwnerOperator): string {
+  return [o.companyName, o.legalName, o.contactEmail, o.dotNumber]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+export function OwnerOperatorPicker({
+  value,
+  onChange,
+  disabled,
+  initialFilter,
+}: OwnerOperatorPickerProps) {
+  const firestore = useFirestore();
+  const [open, setOpen] = useState(false);
+  const [owners, setOwners] = useState<PickerOwnerOperator[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!firestore) return;
+      try {
+        const snap = await getDocs(collection(firestore, 'owner_operators'));
+        if (cancelled) return;
+        const list: PickerOwnerOperator[] = [];
+        snap.forEach((doc) => {
+          const data = doc.data() as Record<string, unknown>;
+          const status = (data.accountStatus as string) || 'active';
+          if (status === 'suspended') return;
+          // Skip admins — we never onboard data on behalf of admin accounts.
+          if (data.isAdmin === true) return;
+          list.push({
+            id: doc.id,
+            companyName: data.companyName as string | undefined,
+            legalName: data.legalName as string | undefined,
+            contactEmail: data.contactEmail as string | undefined,
+            dotNumber: data.dotNumber as string | undefined,
+            accountStatus: status,
+          });
+        });
+        list.sort((a, b) => displayName(a).localeCompare(displayName(b)));
+        setOwners(list);
+      } catch (err) {
+        console.error('[OwnerOperatorPicker] failed to load owner-operators', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [firestore]);
+
+  const selected = useMemo(() => owners.find((o) => o.id === value), [owners, value]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled || loading}
+          className="w-full justify-between font-normal"
+        >
+          {loading ? (
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading accounts…
+            </span>
+          ) : selected ? (
+            <span className="flex items-center gap-2 truncate">
+              <span className="truncate">{displayName(selected)}</span>
+              {selected.accountStatus === 'pre-activated' && (
+                <Badge variant="outline" className="text-xs">
+                  Pre-activated
+                </Badge>
+              )}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">Select an owner-operator…</span>
+          )}
+          <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[min(420px,90vw)] p-0" align="start">
+        <Command
+          filter={(itemValue, search) => {
+            // itemValue is the haystack we attach below; case-insensitive substring
+            return itemValue.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+          }}
+        >
+          <CommandInput
+            placeholder="Search by company, email, or DOT…"
+            defaultValue={initialFilter}
+          />
+          <CommandList>
+            <CommandEmpty>No matching accounts.</CommandEmpty>
+            <CommandGroup>
+              {owners.map((o) => (
+                <CommandItem
+                  key={o.id}
+                  value={searchHaystack(o)}
+                  onSelect={() => {
+                    onChange(o.id, o);
+                    setOpen(false);
+                  }}
+                  className="flex items-center gap-2"
+                >
+                  <Check
+                    className={cn(
+                      'h-4 w-4',
+                      value === o.id ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <div className="flex flex-1 min-w-0 flex-col">
+                    <span className="truncate text-sm">{displayName(o)}</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {o.contactEmail || '—'}
+                      {o.dotNumber ? ` · DOT ${o.dotNumber}` : ''}
+                    </span>
+                  </div>
+                  {o.accountStatus === 'pre-activated' && (
+                    <Badge variant="outline" className="text-xs">
+                      Pre-activated
+                    </Badge>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -9,10 +9,12 @@ export type AuditAction =
   | 'user_deleted'
   | 'user_activation_resent'
   | 'driver_updated'
+  | 'driver_created_by_admin'
   | 'driver_deleted'
   | 'driver_deactivated'
   | 'driver_reactivated'
   | 'load_updated'
+  | 'load_created_by_admin'
   | 'load_deleted'
   | 'match_cancelled'
   | 'match_updated'
@@ -65,10 +67,12 @@ export function getActionLabel(action: AuditAction): string {
     user_deleted: 'User Deleted',
     user_activation_resent: 'Activation Email Sent',
     driver_updated: 'Driver Updated',
+    driver_created_by_admin: 'Driver Created (Admin)',
     driver_deleted: 'Driver Deleted',
     driver_deactivated: 'Driver Deactivated',
     driver_reactivated: 'Driver Reactivated',
     load_updated: 'Load Updated',
+    load_created_by_admin: 'Load Created (Admin)',
     load_deleted: 'Load Deleted',
     match_cancelled: 'Match Cancelled',
     match_updated: 'Match Updated',


### PR DESCRIPTION
## Summary
Closes the white-glove onboarding loop. **DEV-158** let admins pre-register a fleet; **DEV-165** let them form a match on its behalf — but there was no way to populate the fleet's **drivers** or **loads** first. The patented promise of delivering a customer a real compliance-verified match before they ever activate could not be honored end-to-end. This change adds the missing piece.

Closes **[DEV-170](https://xtrafleet-team.atlassian.net/browse/DEV-170)**.

## Decisions (locked on DEV-170)
| # | Decision |
|---|---|
| 1 | Picker → **searchable combobox** (shadcn Command + Popover) |
| 2 | Posting a load with 0 drivers → **allowed** |
| 3 | Default `profileStatus` for admin-created drivers → **`confirmed`** (overridable) |
| 4 | Flow shape → **deep-link CTAs** from `/admin/onboard` success card |
| 5 | Permission split → **reuse** `drivers:edit` and `loads:edit` |

## Changes

### Server routes
- **`POST /api/admin/drivers`** — admin-gated on `drivers:edit`. Zod-validated. Writes under `owner_operators/{ownerId}/drivers/{driverId}` with `createdByAdmin` + `createdAt`. Defaults `profileStatus: 'confirmed'`.
- **`POST /api/admin/loads`** — admin-gated on `loads:edit`. Writes under `owner_operators/{ownerId}/loads/{loadId}` with the same audit fields.
- Both routes audit-log via new `AuditAction` values `driver_created_by_admin` and `load_created_by_admin`.

### UI
- `src/components/admin/owner-operator-picker.tsx` — searchable combobox listing pre-activated + active accounts (excludes admins and suspended), with `Pre-activated` badges.
- `src/components/admin/add-driver-dialog.tsx` — full Add Driver dialog: every customer-facing field, DEV-167 compliance dropdowns, default `profileStatus = confirmed`.
- `src/components/admin/add-load-dialog.tsx` — Add Load dialog with all customer-facing load fields.
- `/admin/drivers` — **Add Driver** button (gated on `drivers:edit`); auto-opens with `?addFor={id}` deep link.
- `/admin/loads` — **Post Load** button (gated on `loads:edit`); same `?addFor` deep link.
- `/admin/onboard` success card — three CTAs after pre-registration: **Add drivers**, **Post loads**, **Form a match** — each deep-links to the relevant admin page with the new account pre-selected.

### Patent invariant
The synchronous compliance gate **still fires** when the admin forms an on-behalf-of match. This ticket adds no shortcut around it.

## Setup Required
None.

## Test plan

**1. End-to-end white-glove flow**
- [ ] As super-admin, `/admin/onboard` → pre-register a real DOT → success card now shows **Add drivers / Post loads / Form a match** CTAs.
- [ ] Click **Add drivers** → `/admin/drivers?addFor={id}` opens with the Add Driver dialog already open and the picker pre-selected to the new account.
- [ ] Fill in name + CDL + medical + insurance + screenings → **Create Driver**.
- [ ] Toast confirms; the dialog closes; the driver appears in the list under the right owner.
- [ ] Back to `/admin/onboard` success card → **Post loads** → dialog opens pre-selected.
- [ ] Fill origin/destination + price + pickup → **Post Load**. Load appears in `/admin/loads`.
- [ ] Final CTA **Form a match** → `/admin/matches?q={id}` filtered to the new account.

**2. Defaults**
- [ ] Admin-created driver has `profileStatus = confirmed` on the saved doc unless overridden.
- [ ] Driver `createdByAdmin` field is your admin uid; `createdAt` is set.
- [ ] Load `createdByAdmin` / `createdAt` populated.

**3. Audit**
- [ ] `/admin/audit` shows two new actions in the filter dropdown: **Driver Created (Admin)** and **Load Created (Admin)**.
- [ ] Each create from above logs an entry with your admin uid + target id.

**4. Permissions**
- [ ] As `support` (audit:view only) → **Add Driver** and **Post Load** buttons not visible; hitting the API endpoints directly returns 403.
- [ ] As `admin` → both buttons visible, both endpoints succeed.

**5. Picker behavior**
- [ ] Picker loads pre-activated + active accounts only — no suspended, no admin accounts.
- [ ] Type a partial company name / email / DOT → list filters.
- [ ] Pre-activated accounts show a `Pre-activated` badge.

**6. Customer-side outcome**
- [ ] Activate the pre-registered account via the activation email link.
- [ ] After password set, lands on `/dashboard` populated with the admin-added drivers, loads, and any pending match — no empty state.

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_

[DEV-170]: https://xtrafleet-team.atlassian.net/browse/DEV-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ