### PR TITLE
feat(billing): make per-match $25 Stripe payment actually work (DEV-84)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -184,5 +184,14 @@ service cloud.firestore {
     match /activation_tokens/{tokenId} {
       allow read, write: if false;
     }
+
+    // Stripe payments (DEV-84). Written ONLY by the server (webhook + refund
+    // routes via Admin SDK). Readable by admins so /admin/billing and
+    // /admin/tlas can render the payment history; not exposed to regular
+    // users — the TLA doc's matchFeePaid flag carries the user-facing state.
+    match /payments/{paymentId} {
+      allow read: if isSignedIn() && isAdmin();
+      allow write: if false;
+    }
   }
 }

--- a/src/app/api/stripe/webhooks/route.ts
+++ b/src/app/api/stripe/webhooks/route.ts
@@ -29,20 +29,88 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
     }
 
-    const adminDb = getAdminDb();
+    // DEV-84: getAdminDb is async — used to be called without `await`, which
+    // meant `adminDb` was a Promise and every `adminDb.collection(...)` call
+    // would throw at runtime. The webhook was effectively a no-op for every
+    // event handler below. Fixing here.
+    const adminDb = await getAdminDb();
 
     // Handle events
     switch (event.type) {
       case 'checkout.session.completed': {
         const session = event.data.object;
         const metadata = session.metadata;
-        
+
         if (metadata?.type === 'match_fee' && metadata?.tlaId) {
-          await adminDb.collection('tlas').doc(metadata.tlaId).update({
-            matchFeePaid: true,
-            matchFeePaymentId: session.payment_intent,
-            matchFeePaidAt: new Date().toISOString(),
-          });
+          // DEV-84: complete the match-fee payment lifecycle.
+          //
+          // The session-completed handler used to ONLY flip the TLA flag and
+          // never wrote to the `payments` collection — which meant the refund
+          // route (DEV-165) and `/admin/billing` had no source of truth.
+          // Now we also write a payments doc and an audit entry, with both
+          // sides idempotent so Stripe's retries don't double-record.
+          const paymentIntentId = String(session.payment_intent || '');
+          const tlaId = metadata.tlaId;
+          const matchId = metadata.matchId || '';
+          const loadOwnerId = metadata.loadOwnerId || '';
+          const nowIso = new Date().toISOString();
+
+          // (1) Write the payments doc using the PaymentIntent id as the doc
+          //     id — guarantees natural idempotency for Stripe retries.
+          if (paymentIntentId) {
+            const paymentRef = adminDb.collection('payments').doc(paymentIntentId);
+            const existingPayment = await paymentRef.get();
+            if (!existingPayment.exists) {
+              await paymentRef.set({
+                id: paymentIntentId,
+                type: 'match_fee',
+                amount: typeof session.amount_total === 'number'
+                  ? session.amount_total
+                  : 2500,
+                currency: session.currency || 'usd',
+                status: 'succeeded',
+                tlaId,
+                matchId,
+                ownerOperatorId: loadOwnerId,
+                stripeSessionId: session.id,
+                stripePaymentIntentId: paymentIntentId,
+                stripeCustomerId: session.customer || null,
+                description: `Match fee for TLA ${tlaId}`,
+                paidAt: nowIso,
+                createdAt: nowIso,
+              });
+            }
+          }
+
+          // (2) Flip the TLA flag — but only if it's not already paid so a
+          //     redelivered event doesn't overwrite the original paidAt.
+          const tlaRef = adminDb.collection('tlas').doc(tlaId);
+          const tlaSnap = await tlaRef.get();
+          const alreadyPaid =
+            tlaSnap.exists && (tlaSnap.data() as { matchFeePaid?: boolean })?.matchFeePaid === true;
+          if (!alreadyPaid) {
+            await tlaRef.update({
+              matchFeePaid: true,
+              matchFeePaymentId: paymentIntentId,
+              matchFeePaidAt: nowIso,
+            });
+
+            // (3) Audit-log the first observation of the payment only.
+            await adminDb.collection('audit_logs').add({
+              action: 'match_fee_paid',
+              userId: loadOwnerId,
+              targetType: 'tla',
+              targetId: tlaId,
+              targetName: `TLA ${tlaId}`,
+              details: {
+                paymentIntentId,
+                matchId,
+                amount: session.amount_total ?? 2500,
+              },
+              timestamp: nowIso,
+              createdAt: nowIso,
+            });
+          }
         }
         
         if (session.mode === 'subscription' && metadata?.userId && session.subscription) {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -23,6 +23,7 @@ export type AuditAction =
   | 'tla_updated'
   | 'tla_deleted'
   | 'billing_refunded'
+  | 'match_fee_paid'
   | 'attestation_voided'
   | 'message_deleted'
   | 'password_reset_sent'
@@ -81,6 +82,7 @@ export function getActionLabel(action: AuditAction): string {
     tla_updated: 'TLA Updated',
     tla_deleted: 'TLA Deleted',
     billing_refunded: 'Payment Refunded',
+    match_fee_paid: 'Match Fee Paid',
     attestation_voided: 'Attestation Voided',
     message_deleted: 'Message Deleted',
     password_reset_sent: 'Password Reset Sent',

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -310,6 +310,11 @@ export type TLA = {
   lesseeSignature?: TLASignature;
   // Bilateral compliance snapshot captured at match formation (DEV-162).
   complianceSnapshot?: ComplianceSnapshot;
+  // $25 match fee paid by the load owner (lessee). Stripe webhook flips
+  // these once the checkout session completes (DEV-84).
+  matchFeePaid?: boolean;
+  matchFeePaymentId?: string;
+  matchFeePaidAt?: string;
   status: 'draft' | 'pending_lessor' | 'pending_lessee' | 'signed' | 'in_progress' | 'completed' | 'voided';
   tripTracking?: {
     startedAt?: string;

--- a/src/lib/tla-actions.ts
+++ b/src/lib/tla-actions.ts
@@ -246,6 +246,15 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
     return null;
   }
 
+  // DEV-84: the $25 match fee must be paid before the trip can start.
+  // TLAMatchFeeCard surfaces the payment CTA to the load owner the moment
+  // the TLA is fully signed — this guard catches any path that tries to
+  // jump straight to start without paying.
+  if (tla.matchFeePaid !== true) {
+    showError("Trip cannot start: match fee has not been paid yet.");
+    return null;
+  }
+
   try {
     const now = new Date().toISOString();
     

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -310,6 +310,44 @@ describe('audit_logs — append-only', () => {
   });
 });
 
+// --- payments: server-only writes, admin-only reads (DEV-84) -------------
+
+describe('payments — server-only writes, admin-only reads (DEV-84)', () => {
+  beforeEach(async () => {
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), 'payments/pi_test1'), {
+        type: 'match_fee',
+        amount: 2500,
+        status: 'succeeded',
+        tlaId: 't1',
+        ownerOperatorId: 'load-owner',
+        createdAt: new Date().toISOString(),
+      });
+    });
+  });
+
+  it('admins can read any payment', async () => {
+    await seedAdmin('admin1');
+    await assertSucceeds(getDoc(doc(asUser('admin1'), 'payments/pi_test1')));
+  });
+
+  it('regular signed-in users cannot read payments', async () => {
+    await seedOwner('load-owner');
+    await assertFails(getDoc(doc(asUser('load-owner'), 'payments/pi_test1')));
+  });
+
+  it('no one can write a payment from the client (server-only)', async () => {
+    await seedOwner('load-owner');
+    await seedAdmin('admin1', 'super_admin');
+    await assertFails(
+      setDoc(doc(asUser('load-owner'), 'payments/new1'), { type: 'match_fee' })
+    );
+    await assertFails(
+      setDoc(doc(asUser('admin1'), 'payments/new1'), { type: 'match_fee' })
+    );
+  });
+});
+
 // --- activation_tokens: server-only (DEV-158) -----------------------------
 
 describe('activation_tokens — server-only (DEV-158)', () => {


### PR DESCRIPTION
## Summary
Per-match $25 payment was about 80% built (Checkout route, webhook skeleton, `TLAMatchFeeCard`, `/admin/billing` viewer, DEV-165 refund flow) but **silently broken end-to-end**. Closes the 4 gaps that kept it from working.

Closes **[DEV-84](https://xtrafleet-team.atlassian.net/browse/DEV-84)**.

## What was broken

| # | Bug | Symptom |
|---|---|---|
| 1 | Webhook called `getAdminDb()` **without `await`**, so `adminDb` was a Promise | Every `adminDb.collection(...)` throws at runtime → webhook is a no-op for **every** event handler (match fees, subscriptions, invoices) |
| 2 | Even with #1 fixed, the webhook only updated the TLA — never wrote to `payments` | Refund flow (DEV-165) 404s on `paymentId`; `/admin/billing` shows no match-fee data |
| 3 | No `payments/{id}` firestore.rules | Admin client reads denied by default → `/admin/billing` and `/admin/tlas` payments query silently empty |
| 4 | `startTrip()` had no `matchFeePaid` guard | A trip could begin on a TLA with no money collected |

## What ships

### Server
- `src/app/api/stripe/webhooks/route.ts`
  - `await getAdminDb()`
  - On `checkout.session.completed` + `metadata.type === 'match_fee'`: write `payments/{paymentIntentId}` with full schema (`type`, `amount`, `status='succeeded'`, `tlaId`, `matchId`, `ownerOperatorId`, `stripeSessionId`, `stripePaymentIntentId`, `paidAt`, `createdAt`). PaymentIntent id as doc id → **natural idempotency** for Stripe retries.
  - Flip the TLA flag + write the `match_fee_paid` audit entry **only if not already paid** — Stripe redelivers events; don't overwrite `paidAt` or double-log.
- `src/lib/tla-actions.ts` (`startTrip`) — refuse to start unless `matchFeePaid === true`; clear toast for the lessor.
- `src/lib/audit.ts` — new `AuditAction` `match_fee_paid` + label.
- `src/lib/data.ts` — declare `matchFeePaid`/`matchFeePaymentId`/`matchFeePaidAt` on the TLA type (used everywhere; previously undeclared).

### Rules
- `firestore.rules` — new `payments/{id}` block: admin-only read, no client writes.
- `tests/rules/firestore-rules.test.ts` — 3 new tests covering admin-can-read / non-admin-cannot-read / no-client-writes. Suite now **32/32**.

## Out of scope
- Subscription billing → DEV-89.
- Failed-payment retry UX → Stripe Checkout handles it.
- ACH / Stripe Connect → DEV-110.

## Setup
- Existing env vars: `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`. Already set on QA + prod.
- Stripe Dashboard → confirm the webhook endpoint points at `/api/stripe/webhooks` and is signed with the matching secret.

## Test plan
**Happy path**
- [ ] Form a match → sign TLA on both sides → load owner sees the **$25 Match Fee Required** card.
- [ ] Pay → Stripe Checkout → success redirect to `?payment=success`.
- [ ] TLA shows **matchFeePaid: true** in Firestore; `payments/{paymentIntentId}` doc created with `status: 'succeeded'`, `type: 'match_fee'`.
- [ ] `/admin/audit` shows `Match Fee Paid` entry.
- [ ] `/admin/billing` shows the payment in the match-fee list.

**Trip-start guard**
- [ ] Same TLA, click **Start Trip** → toast: "Trip cannot start: match fee has not been paid yet." status stays `signed`.
- [ ] After payment, click **Start Trip** → succeeds.

**Idempotency**
- [ ] Re-send the same `checkout.session.completed` event from Stripe Dashboard → no second `payments` doc; no second `matchFeePaidAt`; no second audit entry.

**Refund**
- [ ] As admin on `/admin/tlas` → Process Refund on the paid TLA → Stripe refund created, `payments/{id}.status` flipped to `'refunded'`, audit `billing_refunded` written.

**Rules**
- [ ] As non-admin, `firestore.collection('payments').get()` from console → permission denied.
- [ ] CI **Firestore rules tests** check passes (3 new tests).

https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7jeG1L4bhpW5KtVBXmXpA)_

[DEV-84]: https://xtrafleet-team.atlassian.net/browse/DEV-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ