### PR TITLE
fix(api): security hardening + repair broken Stripe integration (P0/P1 batch)

### DIFF
--- a/src/app/api/add-drivers-bulk/route.ts
+++ b/src/app/api/add-drivers-bulk/route.ts
@@ -44,6 +44,15 @@ async function handlePost(req: NextRequest) {
 
     const { drivers, dqfCertification } = validation.data;
     const ownerDoc = await db.doc(`owner_operators/${ownerUser.uid}`).get();
+
+    // Only actual owner-operators may bulk-invite drivers. This prevents any
+    // other authenticated account (e.g. a driver) from using the endpoint as
+    // an email cannon — invitations are always scoped to ownerUser.uid, and
+    // only owner-operators have an owner_operators profile document.
+    if (!ownerDoc.exists) {
+      throw new Error('Unauthorized');
+    }
+
     const companyName = ownerDoc.data()?.legalName || ownerDoc.data()?.companyName || 'A fleet';
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://xtrafleet.com';
 

--- a/src/app/api/create-driver-account/route.ts
+++ b/src/app/api/create-driver-account/route.ts
@@ -33,6 +33,47 @@ async function handlePost(request: NextRequest) {
     // Get Firebase Admin
     const { auth, db } = await getFirebaseAdmin();
 
+    // SECURITY: Validate the invitation BEFORE creating any account.
+    // The invitation document — not the request body — is the source of truth
+    // for which fleet (ownerId) the driver joins and which email is claimed.
+    // Trusting the body would let an attacker attach a driver to any fleet,
+    // reuse a spent token, or register a different email than was invited.
+    const invitationSnap = await db.collection('driver_invitations').doc(token).get();
+
+    if (!invitationSnap.exists) {
+      throw new Error('Invalid invitation token');
+    }
+
+    const invitation = invitationSnap.data() as any;
+
+    if (invitation.status !== 'pending') {
+      throw new Error('Invitation has already been used or is no longer valid');
+    }
+
+    const expiresAt =
+      typeof invitation.expiresAt?.toDate === 'function'
+        ? invitation.expiresAt.toDate()
+        : invitation.expiresAt
+          ? new Date(invitation.expiresAt)
+          : null;
+    if (expiresAt && expiresAt.getTime() < Date.now()) {
+      throw new Error('Invitation has expired');
+    }
+
+    // The invitation determines the owning fleet — override anything from the body.
+    const resolvedOwnerId: string = invitation.ownerId;
+    if (!resolvedOwnerId) {
+      throw new Error('Invitation is missing an owner');
+    }
+
+    // The email being registered must match the invited email.
+    if (
+      invitation.email &&
+      email.toLowerCase() !== String(invitation.email).toLowerCase()
+    ) {
+      throw new Error('Email does not match the invitation');
+    }
+
     // Create Firebase Auth user
     console.log('[Create Driver] Creating Firebase user:', email);
     const userRecord = await auth.createUser({
@@ -47,12 +88,12 @@ async function handlePost(request: NextRequest) {
     const dqfStatus = driverType === 'newHire' ? 'pending' : 'not_required';
 
     // Save driver profile to Firestore
-    const driverDocRef = db.collection('owner_operators').doc(ownerId).collection('drivers').doc(userRecord.uid);
-    
+    const driverDocRef = db.collection('owner_operators').doc(resolvedOwnerId).collection('drivers').doc(userRecord.uid);
+
     await driverDocRef.set({
       ...profileData,
       id: userRecord.uid,
-      ownerId: ownerId,
+      ownerId: resolvedOwnerId,
       email: email,
       status: 'active',
       availability: 'Available',
@@ -73,7 +114,7 @@ async function handlePost(request: NextRequest) {
     await db.collection('users').doc(userRecord.uid).set({
       role: 'driver',
       email: email,
-      ownerId: ownerId,
+      ownerId: resolvedOwnerId,
       driverId: userRecord.uid,
       driverType: driverType || 'existing', // NEW: Store driver type in user doc
       createdAt: FieldValue.serverTimestamp(),
@@ -109,6 +150,16 @@ async function handlePost(request: NextRequest) {
     
     if (errorMessage.includes('email-already-exists') || errorMessage.includes('already in use')) {
       return handleApiError('conflict', error instanceof Error ? error : new Error(errorMessage), {
+        endpoint: 'POST /api/create-driver-account'
+      });
+    }
+
+    if (
+      errorMessage.includes('invitation') ||
+      errorMessage.includes('Invitation') ||
+      errorMessage.includes('Email does not match')
+    ) {
+      return handleApiError('validation', error instanceof Error ? error : new Error(errorMessage), {
         endpoint: 'POST /api/create-driver-account'
       });
     }

--- a/src/app/api/fmcsa-debug/route.ts
+++ b/src/app/api/fmcsa-debug/route.ts
@@ -8,6 +8,13 @@ import { withCors } from '@/lib/api-cors';
 import { authenticateRequest } from '@/lib/api-auth';
 
 async function handleGet(request: NextRequest) {
+  // Debug endpoint: disabled in production builds unless explicitly opted in
+  // via FMCSA_DEBUG_ENABLED=true. Keeps it usable in local dev and (when needed)
+  // in QA, while keeping it off the live production site by default.
+  if (process.env.NODE_ENV === 'production' && process.env.FMCSA_DEBUG_ENABLED !== 'true') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
   try {
     await authenticateRequest(request);
   } catch {

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { handleApiError, handleApiSuccess } from '@/lib/api-error-handler';
 import { withCors } from '@/lib/api-cors';
+import { authenticateRequest } from '@/lib/api-auth';
 import {
   sendOwnerRegistrationEmail,
   sendDriverRegistrationCompleteEmail,
@@ -16,6 +17,18 @@ import {
 } from '@/lib/email';
 
 async function handlePost(request: NextRequest) {
+  // Require an authenticated caller. All legitimate callers fire from
+  // logged-in dashboard/TLA flows (same-origin fetch sends the fb-id-token
+  // cookie automatically), so this does not change client behavior — it only
+  // closes the open email-relay hole that allowed anonymous abuse.
+  try {
+    await authenticateRequest(request);
+  } catch {
+    return handleApiError('auth', new Error('Unauthorized'), {
+      endpoint: 'POST /api/notifications',
+    });
+  }
+
   try {
     const { type, data } = await request.json();
 

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -14,7 +14,9 @@ export async function POST(request: NextRequest) {
     }
 
     const token = authHeader.substring(7);
-    const decodedToken = await getAdminAuth().verifyIdToken(token);
+    const auth = await getAdminAuth();
+    const adminDb = await getAdminDb();
+    const decodedToken = await auth.verifyIdToken(token);
     const userId = decodedToken.uid;
 
     const body = await request.json();
@@ -25,7 +27,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Get or create Stripe customer
-    const userDoc = await getAdminDb().collection('owner_operators').doc(userId).get();
+    const userDoc = await adminDb.collection('owner_operators').doc(userId).get();
     const userData = userDoc.data();
     let customerId = userData?.stripeCustomerId;
 
@@ -36,7 +38,7 @@ export async function POST(request: NextRequest) {
       });
       customerId = customer.id;
       
-      await getAdminDb().collection('owner_operators').doc(userId).update({
+      await adminDb.collection('owner_operators').doc(userId).update({
         stripeCustomerId: customerId
       });
     }

--- a/src/app/api/stripe/customer-portal/route.ts
+++ b/src/app/api/stripe/customer-portal/route.ts
@@ -15,11 +15,13 @@ export async function POST(request: NextRequest) {
     }
 
     const token = authHeader.substring(7);
-    const decodedToken = await getAdminAuth().verifyIdToken(token);
+    const auth = await getAdminAuth();
+    const adminDb = await getAdminDb();
+    const decodedToken = await auth.verifyIdToken(token);
     const userId = decodedToken.uid;
 
     // Get user data
-    const userDoc = await getAdminDb().collection('owner_operators').doc(userId).get();
+    const userDoc = await adminDb.collection('owner_operators').doc(userId).get();
     const userData = userDoc.data();
 
     if (!userData?.stripeCustomerId) {

--- a/src/app/api/stripe/refund/route.ts
+++ b/src/app/api/stripe/refund/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { FieldValue } from 'firebase-admin/firestore';
+import { authenticateRequest } from '@/lib/api-auth';
+import {
+  hasPermission,
+  getDefaultRoleForLegacyAdmin,
+  type AdminRole,
+} from '@/lib/admin-roles';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -7,17 +13,32 @@ export const dynamic = 'force-dynamic';
 export async function POST(request: NextRequest) {
   try {
     // Dynamic imports to prevent build-time initialization
-    const Stripe = (await import('stripe')).default;
-    const { adminDb } = await import('@/lib/firebase-admin');
-    
-    if (!process.env.STRIPE_SECRET_KEY) {
-      throw new Error('STRIPE_SECRET_KEY is not set');
+    const { stripe } = await import('@/lib/stripe');
+    const { getAdminDb } = await import('@/lib/firebase-admin');
+    const adminDb = await getAdminDb();
+
+    // 1. Authenticate the caller (same-origin cookie auth, matches the admin UI).
+    let caller;
+    try {
+      caller = await authenticateRequest(request);
+    } catch {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
-    
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2024-12-18.acacia',
-    });
-    
+
+    // 2. Authorize: caller must be an admin with the billing:refund permission.
+    const callerDoc = await adminDb.collection('owner_operators').doc(caller.uid).get();
+    const callerData = callerDoc.data();
+    const callerRole: AdminRole | undefined = callerData?.isAdmin
+      ? ((callerData.adminRole as AdminRole) || getDefaultRoleForLegacyAdmin())
+      : undefined;
+
+    if (!callerRole || !hasPermission(callerRole, 'billing:refund')) {
+      return NextResponse.json(
+        { error: 'Access denied. Billing refund permission required.' },
+        { status: 403 }
+      );
+    }
+
     const { paymentId, reason, details, ownerOperatorId } = await request.json();
 
     if (!paymentId || !reason || !details || !ownerOperatorId) {
@@ -39,6 +60,24 @@ export async function POST(request: NextRequest) {
 
     const paymentData = paymentDoc.data();
 
+    // 3. Consistency check: the payment must actually belong to the owner the
+    // caller claims to be refunding. Prevents a malformed/forged request from
+    // refunding one owner's payment while attributing it to another.
+    if (paymentData?.ownerOperatorId !== ownerOperatorId) {
+      return NextResponse.json(
+        { error: 'Payment does not belong to the specified owner operator' },
+        { status: 400 }
+      );
+    }
+
+    // 4. Idempotency: never refund a payment that is already refunded.
+    if (paymentData?.status === 'refunded') {
+      return NextResponse.json(
+        { error: 'Payment has already been refunded' },
+        { status: 409 }
+      );
+    }
+
     if (!paymentData?.stripePaymentIntentId) {
       return NextResponse.json(
         { error: 'No Stripe payment intent found for this payment' },
@@ -55,6 +94,7 @@ export async function POST(request: NextRequest) {
         refund_details: details,
         owner_operator_id: ownerOperatorId,
         admin_refund: 'true',
+        refunded_by: caller.uid,
       },
     });
 
@@ -65,6 +105,7 @@ export async function POST(request: NextRequest) {
       refundReason: reason,
       refundDetails: details,
       stripeRefundId: refund.id,
+      refundedBy: caller.uid,
       updatedAt: FieldValue.serverTimestamp(),
     });
 
@@ -73,7 +114,8 @@ export async function POST(request: NextRequest) {
       action: 'refund_processed',
       entityType: 'payment',
       entityId: paymentId,
-      performedBy: 'admin', // TODO: Get actual admin user ID from session
+      performedBy: caller.uid,
+      performedByEmail: caller.email ?? null,
       ownerOperatorId,
       metadata: {
         amount: paymentData.amount,

--- a/src/app/api/stripe/webhooks/route.ts
+++ b/src/app/api/stripe/webhooks/route.ts
@@ -31,6 +31,16 @@ export async function POST(request: NextRequest) {
 
     const adminDb = await getAdminDb();
 
+    // Idempotency: Stripe retries webhooks (on timeout/non-2xx), so the same
+    // event can arrive more than once. Skip any event we've already fully
+    // processed. The ledger entry is written only AFTER successful handling
+    // below, so a handler that throws is still retried by Stripe.
+    const eventRef = adminDb.collection('stripe_webhook_events').doc(event.id);
+    const alreadyProcessed = await eventRef.get();
+    if (alreadyProcessed.exists) {
+      return NextResponse.json({ received: true, duplicate: true });
+    }
+
     // Handle events
     switch (event.type) {
       case 'checkout.session.completed': {
@@ -128,6 +138,12 @@ export async function POST(request: NextRequest) {
         break;
       }
     }
+
+    // Record the event as processed so any retry is treated as a duplicate.
+    await eventRef.set({
+      type: event.type,
+      processedAt: new Date().toISOString(),
+    });
 
     return NextResponse.json({ received: true });
   } catch (error: any) {

--- a/src/app/api/stripe/webhooks/route.ts
+++ b/src/app/api/stripe/webhooks/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
     }
 
-    const adminDb = getAdminDb();
+    const adminDb = await getAdminDb();
 
     // Handle events
     switch (event.type) {

--- a/src/lib/tla-actions.ts
+++ b/src/lib/tla-actions.ts
@@ -1,4 +1,4 @@
-import { Firestore, doc, updateDoc, getDoc, Timestamp } from "firebase/firestore";
+import { Firestore, doc, updateDoc, getDoc, Timestamp, runTransaction } from "firebase/firestore";
 import type { TLA, InsuranceOption } from "@/lib/data";
 import { showSuccess, showError } from "@/lib/toast-utils";
 import { notify } from "@/lib/notifications";
@@ -30,181 +30,163 @@ export interface TripActionParams {
  */
 export async function signTLA(params: SignTLAParams): Promise<TLA | null> {
   const { firestore, tlaId, tla, userId, signatureName, role, insuranceOption, locations } = params;
-  
+
   try {
-    // Capture audit trail data
+    // Capture audit trail data (does network I/O — must run before the transaction)
     const auditData = await captureSignatureAudit();
-    
+
     const signature = {
       signedBy: userId,
       signedByName: signatureName,
       signedByRole: role,
       signedAt: auditData.timestamp,
-      // NEW: E-signature audit trail fields
+      // E-signature audit trail fields
       ipAddress: auditData.ipAddress,
       userAgent: auditData.userAgent,
       consentToEsign: true, // User explicitly checked the consent box
     };
-    
-    const updateData: Record<string, any> = {
-      updatedAt: new Date().toISOString(),
-    };
-    
-    // Determine the other party's signature status
-    const otherPartyHasSigned = role === 'lessor' ? !!tla.lesseeSignature : !!tla.lessorSignature;
-    
-    if (role === 'lessor') {
-      updateData.lessorSignature = signature;
-      
-      if (otherPartyHasSigned) {
-        // Both have now signed
-        updateData.status = 'signed';
-        updateData.signedAt = new Date().toISOString();
-        
-        // Notify both parties
-        await Promise.all([
-          notify.tlaSigned({
-            recipientEmail: tla.lessor.contactEmail,
-            recipientName: tla.lessor.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessor:', err)),
-          
-          notify.tlaSigned({
-            recipientEmail: tla.lessee.contactEmail,
-            recipientName: tla.lessee.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessee:', err)),
-        ]);
-      } else {
-        // Waiting for lessee to sign
-        updateData.status = 'pending_lessee';
-        
-        notify.tlaReady({
-          recipientEmail: tla.lessee.contactEmail,
-          recipientName: tla.lessee.legalName,
-          role: 'lessee',
-          driverName: tla.driver.name,
-          loadOrigin: tla.trip.origin,
-          loadDestination: tla.trip.destination,
-          rate: tla.payment.amount,
-          tlaId: tlaId,
-        }).catch(err => console.error('Failed to send TLA ready notification:', err));
-      }
-      
-    } else if (role === 'lessee') {
-      updateData.lesseeSignature = signature;
 
-      if (insuranceOption) {
-        updateData.insurance = {
-          option: insuranceOption,
-          confirmedAt: new Date().toISOString(),
-          confirmedBy: userId,
-        };
+    // Apply the signature inside a transaction so the "has the other party
+    // signed?" decision is made from the CURRENT document, not the stale `tla`
+    // snapshot captured at page load. Previously, two parties signing
+    // concurrently could each read the other as unsigned and the second write
+    // would clobber the status back to pending_*, stranding a fully-signed TLA.
+    const tlaRef = doc(firestore, `tlas/${tlaId}`);
+
+    const { bothSigned } = await runTransaction(firestore, async (transaction) => {
+      const snap = await transaction.get(tlaRef);
+      if (!snap.exists()) {
+        throw new Error('TLA not found');
+      }
+      const current = snap.data() as TLA;
+
+      // Resolve both signatures from fresh data, including the one we're adding.
+      const lessorSignature = role === 'lessor' ? signature : current.lessorSignature;
+      const lesseeSignature = role === 'lessee' ? signature : current.lesseeSignature;
+      const both = !!lessorSignature && !!lesseeSignature;
+
+      const updateData: Record<string, any> = {
+        updatedAt: new Date().toISOString(),
+      };
+
+      if (role === 'lessor') {
+        updateData.lessorSignature = signature;
+      } else {
+        updateData.lesseeSignature = signature;
+
+        if (insuranceOption) {
+          updateData.insurance = {
+            option: insuranceOption,
+            confirmedAt: new Date().toISOString(),
+            confirmedBy: userId,
+          };
+        }
+
+        // Save location details if provided
+        if (locations) {
+          updateData.locations = locations;
+        }
       }
 
-      // Save location details if provided
-      if (locations) {
-        updateData.locations = locations;
-      }
-      
-      if (otherPartyHasSigned) {
-        // Both have now signed
+      if (both) {
         updateData.status = 'signed';
         updateData.signedAt = new Date().toISOString();
-        
-        // Notify both parties
-        await Promise.all([
-          notify.tlaSigned({
-            recipientEmail: tla.lessor.contactEmail,
-            recipientName: tla.lessor.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessor:', err)),
-          
-          notify.tlaSigned({
-            recipientEmail: tla.lessee.contactEmail,
-            recipientName: tla.lessee.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessee:', err)),
-        ]);
       } else {
-        // Waiting for lessor to sign
-        updateData.status = 'pending_lessor';
-        
-        notify.tlaReady({
+        // Whoever just signed is recorded; the OTHER party is still pending.
+        updateData.status = lessorSignature ? 'pending_lessee' : 'pending_lessor';
+      }
+
+      transaction.update(tlaRef, updateData);
+      return { bothSigned: both };
+    });
+
+    // ---- Side effects: only after the transaction commits ----
+    // Kept outside the transaction because the transaction body can be retried,
+    // and we must never send duplicate emails or perform external writes inside it.
+    if (bothSigned) {
+      // Notify both parties that the TLA is fully signed.
+      await Promise.all([
+        notify.tlaSigned({
           recipientEmail: tla.lessor.contactEmail,
           recipientName: tla.lessor.legalName,
-          role: 'lessor',
           driverName: tla.driver.name,
           loadOrigin: tla.trip.origin,
           loadDestination: tla.trip.destination,
           rate: tla.payment.amount,
           tlaId: tlaId,
-        }).catch(err => console.error('Failed to send TLA ready notification:', err));
-      }
-    }
-    
-    await updateDoc(doc(firestore, `tlas/${tlaId}`), updateData);
-    
-    // Update match status and create conversation if both signed
-    if (updateData.status === 'signed' && tla.matchId) {
-      try {
-        await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
-          status: 'tla_signed',
-        });
-      } catch (matchErr) {
-        console.warn("Could not update match status:", matchErr);
-      }
+        }).catch(err => console.error('Failed to notify lessor:', err)),
 
-      // Create conversation now that TLA is fully signed
-      try {
-        const matchDoc = await getDoc(doc(firestore, `matches/${tla.matchId}`));
-        if (matchDoc.exists()) {
-          const matchData = matchDoc.data();
-          if (matchData.loadId && matchData.loadOwnerId) {
-            await createConversation(
-              firestore,
-              tla.lessor.ownerOperatorId,  // driver owner (lessor)
-              matchData.loadOwnerId,        // load owner (lessee)
-              matchData.loadId,
-              tlaId
-            );
-            console.log("✅ Conversation created for TLA:", tlaId);
-          }
+        notify.tlaSigned({
+          recipientEmail: tla.lessee.contactEmail,
+          recipientName: tla.lessee.legalName,
+          driverName: tla.driver.name,
+          loadOrigin: tla.trip.origin,
+          loadDestination: tla.trip.destination,
+          rate: tla.payment.amount,
+          tlaId: tlaId,
+        }).catch(err => console.error('Failed to notify lessee:', err)),
+      ]);
+
+      // Update match status and create conversation now that both have signed.
+      if (tla.matchId) {
+        try {
+          await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
+            status: 'tla_signed',
+          });
+        } catch (matchErr) {
+          console.warn("Could not update match status:", matchErr);
         }
-      } catch (convErr) {
-        // Non-fatal — log but don't block the sign flow
-        console.warn("Could not create conversation:", convErr);
+
+        // Create conversation now that TLA is fully signed
+        try {
+          const matchDoc = await getDoc(doc(firestore, `matches/${tla.matchId}`));
+          if (matchDoc.exists()) {
+            const matchData = matchDoc.data();
+            if (matchData.loadId && matchData.loadOwnerId) {
+              await createConversation(
+                firestore,
+                tla.lessor.ownerOperatorId,  // driver owner (lessor)
+                matchData.loadOwnerId,        // load owner (lessee)
+                matchData.loadId,
+                tlaId
+              );
+              console.log("✅ Conversation created for TLA:", tlaId);
+            }
+          }
+        } catch (convErr) {
+          // Non-fatal — log but don't block the sign flow
+          console.warn("Could not create conversation:", convErr);
+        }
       }
+    } else {
+      // Only one party has signed — notify the party who still needs to sign.
+      const pendingRole: 'lessor' | 'lessee' = role === 'lessor' ? 'lessee' : 'lessor';
+      const recipient = pendingRole === 'lessee' ? tla.lessee : tla.lessor;
+
+      notify.tlaReady({
+        recipientEmail: recipient.contactEmail,
+        recipientName: recipient.legalName,
+        role: pendingRole,
+        driverName: tla.driver.name,
+        loadOrigin: tla.trip.origin,
+        loadDestination: tla.trip.destination,
+        rate: tla.payment.amount,
+        tlaId: tlaId,
+      }).catch(err => console.error('Failed to send TLA ready notification:', err));
     }
-    
+
     showSuccess(
-      otherPartyHasSigned 
-        ? "TLA fully signed! Trip can now begin." 
+      bothSigned
+        ? "TLA fully signed! Trip can now begin."
         : `Signed! Waiting for ${role === 'lessor' ? 'lessee' : 'lessor'} to sign.`
     );
-    
+
     // Fetch and return updated TLA
     const updatedDoc = await getDoc(doc(firestore, `tlas/${tlaId}`));
     if (updatedDoc.exists()) {
       return { id: updatedDoc.id, ...updatedDoc.data() } as TLA;
     }
-    
+
     return null;
   } catch (error) {
     console.error("Error signing TLA:", error);
@@ -218,10 +200,10 @@ export async function signTLA(params: SignTLAParams): Promise<TLA | null> {
  */
 export async function startTrip(params: TripActionParams): Promise<TLA | null> {
   const { firestore, tlaId, tla, userId, userName } = params;
-  
+
   try {
     const now = new Date().toISOString();
-    
+
     const updateData = {
       status: 'in_progress',
       tripTracking: {
@@ -231,16 +213,16 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
       },
       updatedAt: now,
     };
-    
+
     await updateDoc(doc(firestore, `tlas/${tlaId}`), updateData);
-    
+
     // Update match status
     if (tla.matchId) {
       await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
         status: 'in_progress',
       }).catch(err => console.warn("Could not update match:", err));
     }
-    
+
     // Update driver availability
     try {
       const driverRef = doc(firestore, `owner_operators/${tla.lessor.ownerOperatorId}/drivers/${tla.driver.id}`);
@@ -248,7 +230,7 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
     } catch (err) {
       console.warn("Could not update driver availability:", err);
     }
-    
+
     // Send notifications
     await Promise.all([
       notify.tripStarted({
@@ -261,7 +243,7 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
         tlaId: tlaId,
         startedByName: userName,
       }).catch(err => console.error('Failed to notify lessor:', err)),
-      
+
       notify.tripStarted({
         recipientEmail: tla.lessee.contactEmail,
         recipientName: tla.lessee.legalName,
@@ -273,15 +255,15 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
         startedByName: userName,
       }).catch(err => console.error('Failed to notify lessee:', err)),
     ]);
-    
+
     showSuccess("Trip started! Both parties have been notified.");
-    
+
     // Fetch and return updated TLA
     const updatedDoc = await getDoc(doc(firestore, `tlas/${tlaId}`));
     if (updatedDoc.exists()) {
       return { id: updatedDoc.id, ...updatedDoc.data() } as TLA;
     }
-    
+
     return null;
   } catch (error) {
     console.error("Error starting trip:", error);
@@ -295,16 +277,16 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
  */
 export async function endTrip(params: TripActionParams): Promise<TLA | null> {
   const { firestore, tlaId, tla, userId, userName } = params;
-  
+
   if (!tla.tripTracking?.startedAt) {
     showError("Trip has not been started yet.");
     return null;
   }
-  
+
   try {
     const now = new Date().toISOString();
     const durationMinutes = calculateTripDuration(tla.tripTracking.startedAt, now);
-    
+
     const updateData = {
       status: 'completed',
       tripTracking: {
@@ -316,16 +298,16 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
       },
       updatedAt: now,
     };
-    
+
     await updateDoc(doc(firestore, `tlas/${tlaId}`), updateData);
-    
+
     // Update match status
     if (tla.matchId) {
       await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
         status: 'completed',
       }).catch(err => console.warn("Could not update match:", err));
     }
-    
+
     // Update load status
     if (tla.matchId) {
       try {
@@ -343,9 +325,9 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
         console.warn("Could not update load status:", err);
       }
     }
-    
+
     const tripDurationStr = formatTripDuration(durationMinutes);
-    
+
     // Send notifications
     await Promise.all([
       notify.tripCompleted({
@@ -359,7 +341,7 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
         endedByName: userName,
         tripDuration: tripDurationStr,
       }).catch(err => console.error('Failed to notify lessor:', err)),
-      
+
       notify.tripCompleted({
         recipientEmail: tla.lessee.contactEmail,
         recipientName: tla.lessee.legalName,
@@ -372,13 +354,13 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
         tripDuration: tripDurationStr,
       }).catch(err => console.error('Failed to notify lessee:', err)),
     ]);
-    
+
     // Fetch and return updated TLA
     const updatedDoc = await getDoc(doc(firestore, `tlas/${tlaId}`));
     if (updatedDoc.exists()) {
       return { id: updatedDoc.id, ...updatedDoc.data() } as TLA;
     }
-    
+
     return null;
   } catch (error) {
     console.error("Error ending trip:", error);
@@ -397,8 +379,8 @@ export async function updateDriverAvailability(
 ): Promise<void> {
   try {
     const driverRef = doc(firestore, `owner_operators/${tla.lessor.ownerOperatorId}/drivers/${tla.driver.id}`);
-    await updateDoc(driverRef, { 
-      availability: markAvailable ? 'Available' : 'Off-duty' 
+    await updateDoc(driverRef, {
+      availability: markAvailable ? 'Available' : 'Off-duty'
     });
     showSuccess(
       `Trip completed! Driver marked as ${markAvailable ? 'Available' : 'Off-duty'}.`


### PR DESCRIPTION
**Closed in favor of a qa-based branch.**

This branch was cut from `main`, so it carried stale versions of files that `qa` has already advanced (DEV-84, DEV-165). Merging it into `qa` would conflict with, and in places regress, existing qa work. Comparison showed:
- Already fixed on qa (don't port): `stripe/refund` auth (DEV-165), `stripe/webhooks` idempotency+await (DEV-84, more complete than this branch).
- Genuinely missing on qa (being re-applied on a fresh qa-based branch): `notifications` auth, `create-driver-account` invitation binding, `add-drivers-bulk` owner check, `fmcsa-debug` prod guard, `stripe/customer-portal` await fix, `stripe/create-checkout-session` await fix, and the `tla-actions` signing race fix.

The 7 net-new fixes will land via a new PR based on `qa`.

https://claude.ai/code/session_013vvYfAbxCM1R7wvaiJ97re