### PR TITLE
fix(admin): make owner-operator picker list scrollable in Add Driver / Post Load dialogs

### DIFF
--- a/src/components/admin/owner-operator-picker.tsx
+++ b/src/components/admin/owner-operator-picker.tsx
@@ -105,7 +105,13 @@ export function OwnerOperatorPicker({
   const selected = useMemo(() => owners.find((o) => o.id === value), [owners, value]);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    // `modal` is required because this picker renders inside a Radix Dialog
+    // (the "Add Driver" / "Post Load" dialogs). Without it, the Popover's
+    // portaled content lives outside the Dialog's scroll-lock subtree, so the
+    // Dialog's react-remove-scroll blocks mouse-wheel events on the list —
+    // the user could only move through results with the arrow keys. A modal
+    // Popover manages its own scroll region, restoring wheel/scrollbar scrolling.
+    <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>
         <Button
           type="button"


### PR DESCRIPTION
## Summary
- Fixes the owner-operator picker in the admin **Add Driver** / **Post Load** dialogs, where the dropdown list of accounts couldn't be scrolled with the mouse — you could only move through the ~21 entries with the arrow keys.

## Root cause
The picker (`OwnerOperatorPicker`) uses a Radix `Popover`, and `PopoverContent` is rendered through a **Portal** (to `document.body`). The dialogs that host the picker are Radix `Dialog`s, whose scroll-lock (`react-remove-scroll`) blocks mouse-wheel/touch scroll on anything outside the dialog's own DOM subtree. Because the portaled list lives outside that subtree, wheel/scrollbar scrolling was blocked; cmdk keyboard navigation still scrolled the highlighted row into view, which is why arrow keys appeared to work but the wheel didn't.

## Change
- Set the nested `Popover` to `modal` in `src/components/admin/owner-operator-picker.tsx`. A modal Popover establishes its own scroll region, so the results list scrolls with the wheel/scrollbar again. One-line behavioral change; no layout change — the list keeps its existing max-height and type-to-filter search.

## Setup Required
- None.

## Test Plan
- [ ] Admin → Drivers → **Add Driver**: open the Owner Operator dropdown; scroll the full list with the mouse wheel and the scrollbar; type-to-filter still works; selecting an account closes the dropdown and populates the field.
- [ ] Admin → Loads → **Post Load**: same checks.
- [ ] After selecting, the rest of the dialog (form fields, Cancel/submit) is interactive again.
- [ ] Keyboard: arrow keys + Enter still select an account.

## Notes
- This is independent of security PR #203 (that one is based on `main`; this feature lives only on `qa`, which is why this PR branches from `qa`).
- I couldn't run the hosted QA app from my environment, so the change is verified by typecheck + production build only — please give it a quick visual check once it deploys to QA.

https://claude.ai/code/session_013vvYfAbxCM1R7wvaiJ97re

---
_Generated by [Claude Code](https://claude.ai/code/session_013vvYfAbxCM1R7wvaiJ97re)_