### PR TITLE
fix(security): close 7 gaps still present on qa (auth, invitation binding, Stripe await, TLA signing race)

### DIFF
--- a/src/app/api/add-drivers-bulk/route.ts
+++ b/src/app/api/add-drivers-bulk/route.ts
@@ -64,6 +64,15 @@ async function handlePost(req: NextRequest) {
       throw new Error('Driver add attestations are required.');
     }
     const ownerDoc = await db.doc(`owner_operators/${ownerUser.uid}`).get();
+
+    // Only actual owner-operators may bulk-invite drivers. This prevents any
+    // other authenticated account (e.g. a driver) from using the endpoint as
+    // an email cannon — invitations are always scoped to ownerUser.uid, and
+    // only owner-operators have an owner_operators profile document.
+    if (!ownerDoc.exists) {
+      throw new Error('Unauthorized');
+    }
+
     const companyName = ownerDoc.data()?.legalName || ownerDoc.data()?.companyName || 'A fleet';
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://xtrafleet.com';
 

--- a/src/app/api/create-driver-account/route.ts
+++ b/src/app/api/create-driver-account/route.ts
@@ -33,6 +33,47 @@ async function handlePost(request: NextRequest) {
     // Get Firebase Admin
     const { auth, db } = await getFirebaseAdmin();
 
+    // SECURITY: Validate the invitation BEFORE creating any account.
+    // The invitation document — not the request body — is the source of truth
+    // for which fleet (ownerId) the driver joins and which email is claimed.
+    // Trusting the body would let an attacker attach a driver to any fleet,
+    // reuse a spent token, or register a different email than was invited.
+    const invitationSnap = await db.collection('driver_invitations').doc(token).get();
+
+    if (!invitationSnap.exists) {
+      throw new Error('Invalid invitation token');
+    }
+
+    const invitation = invitationSnap.data() as any;
+
+    if (invitation.status !== 'pending') {
+      throw new Error('Invitation has already been used or is no longer valid');
+    }
+
+    const invitationExpiresAt =
+      typeof invitation.expiresAt?.toDate === 'function'
+        ? invitation.expiresAt.toDate()
+        : invitation.expiresAt
+          ? new Date(invitation.expiresAt)
+          : null;
+    if (invitationExpiresAt && invitationExpiresAt.getTime() < Date.now()) {
+      throw new Error('Invitation has expired');
+    }
+
+    // The invitation determines the owning fleet — override anything from the body.
+    const resolvedOwnerId: string = invitation.ownerId;
+    if (!resolvedOwnerId) {
+      throw new Error('Invitation is missing an owner');
+    }
+
+    // The email being registered must match the invited email.
+    if (
+      invitation.email &&
+      email.toLowerCase() !== String(invitation.email).toLowerCase()
+    ) {
+      throw new Error('Email does not match the invitation');
+    }
+
     // Create Firebase Auth user
     console.log('[Create Driver] Creating Firebase user:', email);
     const userRecord = await auth.createUser({
@@ -47,12 +88,12 @@ async function handlePost(request: NextRequest) {
     const dqfStatus = driverType === 'newHire' ? 'pending' : 'not_required';
 
     // Save driver profile to Firestore
-    const driverDocRef = db.collection('owner_operators').doc(ownerId).collection('drivers').doc(userRecord.uid);
-    
+    const driverDocRef = db.collection('owner_operators').doc(resolvedOwnerId).collection('drivers').doc(userRecord.uid);
+
     await driverDocRef.set({
       ...profileData,
       id: userRecord.uid,
-      ownerId: ownerId,
+      ownerId: resolvedOwnerId,
       email: email,
       status: 'active',
       availability: 'Available',
@@ -73,7 +114,7 @@ async function handlePost(request: NextRequest) {
     await db.collection('users').doc(userRecord.uid).set({
       role: 'driver',
       email: email,
-      ownerId: ownerId,
+      ownerId: resolvedOwnerId,
       driverId: userRecord.uid,
       driverType: driverType || 'existing', // NEW: Store driver type in user doc
       createdAt: FieldValue.serverTimestamp(),
@@ -112,7 +153,17 @@ async function handlePost(request: NextRequest) {
         endpoint: 'POST /api/create-driver-account'
       });
     }
-    
+
+    if (
+      errorMessage.includes('invitation') ||
+      errorMessage.includes('Invitation') ||
+      errorMessage.includes('Email does not match')
+    ) {
+      return handleApiError('validation', error instanceof Error ? error : new Error(errorMessage), {
+        endpoint: 'POST /api/create-driver-account'
+      });
+    }
+
     // Generic server error
     return handleApiError('server', error instanceof Error ? error : new Error(errorMessage), {
       endpoint: 'POST /api/create-driver-account'

--- a/src/app/api/fmcsa-debug/route.ts
+++ b/src/app/api/fmcsa-debug/route.ts
@@ -11,6 +11,13 @@ import { authenticateRequest } from '@/lib/api-auth';
 import { fetchSAFERDebug, fetchLIDebug, fetchSocrataDebug } from '@/lib/fmcsa';
 
 async function handleGet(request: NextRequest) {
+  // Debug endpoint: disabled in production builds unless explicitly opted in
+  // via FMCSA_DEBUG_ENABLED=true. Keeps it usable in local dev and (when needed)
+  // in QA, while keeping it off the live production site by default.
+  if (process.env.NODE_ENV === 'production' && process.env.FMCSA_DEBUG_ENABLED !== 'true') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
   try {
     await authenticateRequest(request);
   } catch {

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { handleApiError, handleApiSuccess } from '@/lib/api-error-handler';
 import { withCors } from '@/lib/api-cors';
+import { authenticateRequest } from '@/lib/api-auth';
 import {
   sendOwnerRegistrationEmail,
   sendDriverRegistrationCompleteEmail,
@@ -16,6 +17,18 @@ import {
 } from '@/lib/email';
 
 async function handlePost(request: NextRequest) {
+  // Require an authenticated caller. All legitimate callers fire from
+  // logged-in dashboard/TLA flows (same-origin fetch sends the fb-id-token
+  // cookie automatically), so this does not change client behavior — it only
+  // closes the open email-relay hole that allowed anonymous abuse.
+  try {
+    await authenticateRequest(request);
+  } catch {
+    return handleApiError('auth', new Error('Unauthorized'), {
+      endpoint: 'POST /api/notifications',
+    });
+  }
+
   try {
     const { type, data } = await request.json();
 

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -14,7 +14,9 @@ export async function POST(request: NextRequest) {
     }
 
     const token = authHeader.substring(7);
-    const decodedToken = await getAdminAuth().verifyIdToken(token);
+    const auth = await getAdminAuth();
+    const adminDb = await getAdminDb();
+    const decodedToken = await auth.verifyIdToken(token);
     const userId = decodedToken.uid;
 
     const body = await request.json();
@@ -25,7 +27,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Get or create Stripe customer
-    const userDoc = await getAdminDb().collection('owner_operators').doc(userId).get();
+    const userDoc = await adminDb.collection('owner_operators').doc(userId).get();
     const userData = userDoc.data();
     let customerId = userData?.stripeCustomerId;
 
@@ -36,7 +38,7 @@ export async function POST(request: NextRequest) {
       });
       customerId = customer.id;
       
-      await getAdminDb().collection('owner_operators').doc(userId).update({
+      await adminDb.collection('owner_operators').doc(userId).update({
         stripeCustomerId: customerId
       });
     }

--- a/src/app/api/stripe/customer-portal/route.ts
+++ b/src/app/api/stripe/customer-portal/route.ts
@@ -15,11 +15,13 @@ export async function POST(request: NextRequest) {
     }
 
     const token = authHeader.substring(7);
-    const decodedToken = await getAdminAuth().verifyIdToken(token);
+    const auth = await getAdminAuth();
+    const adminDb = await getAdminDb();
+    const decodedToken = await auth.verifyIdToken(token);
     const userId = decodedToken.uid;
 
     // Get user data
-    const userDoc = await getAdminDb().collection('owner_operators').doc(userId).get();
+    const userDoc = await adminDb.collection('owner_operators').doc(userId).get();
     const userData = userDoc.data();
 
     if (!userData?.stripeCustomerId) {

--- a/src/lib/tla-actions.ts
+++ b/src/lib/tla-actions.ts
@@ -1,4 +1,4 @@
-import { Firestore, doc, updateDoc, getDoc, arrayUnion } from "firebase/firestore";
+import { Firestore, doc, updateDoc, getDoc, arrayUnion, runTransaction } from "firebase/firestore";
 import type { TLA, InsuranceOption } from "@/lib/data";
 import { showSuccess, showError } from "@/lib/toast-utils";
 import { notify } from "@/lib/notifications";
@@ -31,136 +31,79 @@ export interface TripActionParams {
  */
 export async function signTLA(params: SignTLAParams): Promise<TLA | null> {
   const { firestore, tlaId, tla, userId, signatureName, role, insuranceOption, locations } = params;
-  
+
   try {
-    // Capture audit trail data
+    // Capture audit trail data (does network I/O — must run before the transaction)
     const auditData = await captureSignatureAudit();
-    
+
     const signature = {
       signedBy: userId,
       signedByName: signatureName,
       signedByRole: role,
       signedAt: auditData.timestamp,
-      // NEW: E-signature audit trail fields
+      // E-signature audit trail fields
       ipAddress: auditData.ipAddress,
       userAgent: auditData.userAgent,
       consentToEsign: true, // User explicitly checked the consent box
     };
-    
-    const updateData: Record<string, any> = {
-      updatedAt: new Date().toISOString(),
-    };
-    
-    // Determine the other party's signature status
-    const otherPartyHasSigned = role === 'lessor' ? !!tla.lesseeSignature : !!tla.lessorSignature;
-    
-    if (role === 'lessor') {
-      updateData.lessorSignature = signature;
-      
-      if (otherPartyHasSigned) {
-        // Both have now signed
-        updateData.status = 'signed';
-        updateData.signedAt = new Date().toISOString();
-        
-        // Notify both parties
-        await Promise.all([
-          notify.tlaSigned({
-            recipientEmail: tla.lessor.contactEmail,
-            recipientName: tla.lessor.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessor:', err)),
-          
-          notify.tlaSigned({
-            recipientEmail: tla.lessee.contactEmail,
-            recipientName: tla.lessee.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessee:', err)),
-        ]);
-      } else {
-        // Waiting for lessee to sign
-        updateData.status = 'pending_lessee';
-        
-        notify.tlaReady({
-          recipientEmail: tla.lessee.contactEmail,
-          recipientName: tla.lessee.legalName,
-          role: 'lessee',
-          driverName: tla.driver.name,
-          loadOrigin: tla.trip.origin,
-          loadDestination: tla.trip.destination,
-          rate: tla.payment.amount,
-          tlaId: tlaId,
-        }).catch(err => console.error('Failed to send TLA ready notification:', err));
-      }
-      
-    } else if (role === 'lessee') {
-      updateData.lesseeSignature = signature;
 
-      if (insuranceOption) {
-        updateData.insurance = {
-          option: insuranceOption,
-          confirmedAt: new Date().toISOString(),
-          confirmedBy: userId,
-        };
+    // Apply the signature inside a transaction so the "has the other party
+    // signed?" decision is made from the CURRENT document, not the stale `tla`
+    // snapshot captured at page load. Previously, two parties signing
+    // concurrently could each read the other as unsigned and the second write
+    // would clobber the status back to pending_*, stranding a fully-signed TLA.
+    const tlaRef = doc(firestore, `tlas/${tlaId}`);
+
+    const { bothSigned } = await runTransaction(firestore, async (transaction) => {
+      const snap = await transaction.get(tlaRef);
+      if (!snap.exists()) {
+        throw new Error('TLA not found');
+      }
+      const current = snap.data() as TLA;
+
+      // Resolve both signatures from fresh data, including the one we're adding.
+      const lessorSignature = role === 'lessor' ? signature : current.lessorSignature;
+      const lesseeSignature = role === 'lessee' ? signature : current.lesseeSignature;
+      const both = !!lessorSignature && !!lesseeSignature;
+
+      const updateData: Record<string, any> = {
+        updatedAt: new Date().toISOString(),
+      };
+
+      if (role === 'lessor') {
+        updateData.lessorSignature = signature;
+      } else {
+        updateData.lesseeSignature = signature;
+
+        if (insuranceOption) {
+          updateData.insurance = {
+            option: insuranceOption,
+            confirmedAt: new Date().toISOString(),
+            confirmedBy: userId,
+          };
+        }
+
+        // Save location details if provided
+        if (locations) {
+          updateData.locations = locations;
+        }
       }
 
-      // Save location details if provided
-      if (locations) {
-        updateData.locations = locations;
-      }
-      
-      if (otherPartyHasSigned) {
-        // Both have now signed
+      if (both) {
         updateData.status = 'signed';
         updateData.signedAt = new Date().toISOString();
-        
-        // Notify both parties
-        await Promise.all([
-          notify.tlaSigned({
-            recipientEmail: tla.lessor.contactEmail,
-            recipientName: tla.lessor.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessor:', err)),
-          
-          notify.tlaSigned({
-            recipientEmail: tla.lessee.contactEmail,
-            recipientName: tla.lessee.legalName,
-            driverName: tla.driver.name,
-            loadOrigin: tla.trip.origin,
-            loadDestination: tla.trip.destination,
-            rate: tla.payment.amount,
-            tlaId: tlaId,
-          }).catch(err => console.error('Failed to notify lessee:', err)),
-        ]);
       } else {
-        // Waiting for lessor to sign
-        updateData.status = 'pending_lessor';
-        
-        notify.tlaReady({
-          recipientEmail: tla.lessor.contactEmail,
-          recipientName: tla.lessor.legalName,
-          role: 'lessor',
-          driverName: tla.driver.name,
-          loadOrigin: tla.trip.origin,
-          loadDestination: tla.trip.destination,
-          rate: tla.payment.amount,
-          tlaId: tlaId,
-        }).catch(err => console.error('Failed to send TLA ready notification:', err));
+        // Whoever just signed is recorded; the OTHER party is still pending.
+        updateData.status = lessorSignature ? 'pending_lessee' : 'pending_lessor';
       }
-    }
-    
-    await updateDoc(doc(firestore, `tlas/${tlaId}`), updateData);
+
+      transaction.update(tlaRef, updateData);
+      return { bothSigned: both };
+    });
+
+    // ---- Side effects: only after the transaction commits ----
+    // Kept outside the transaction because the transaction body can be retried,
+    // and we must never send duplicate emails or perform external writes inside it.
 
     // DEV-154 phase 4: also append the e-sign consent to the signer's
     // unified attestations array, with context.tlaId. The existing
@@ -180,50 +123,90 @@ export async function signTLA(params: SignTLAParams): Promise<TLA | null> {
       console.error('Failed to record TLA e-sign attestation:', err);
     }
 
-    // Update match status and create conversation if both signed
-    if (updateData.status === 'signed' && tla.matchId) {
-      try {
-        await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
-          status: 'tla_signed',
-        });
-      } catch (matchErr) {
-        console.warn("Could not update match status:", matchErr);
-      }
+    if (bothSigned) {
+      // Notify both parties that the TLA is fully signed.
+      await Promise.all([
+        notify.tlaSigned({
+          recipientEmail: tla.lessor.contactEmail,
+          recipientName: tla.lessor.legalName,
+          driverName: tla.driver.name,
+          loadOrigin: tla.trip.origin,
+          loadDestination: tla.trip.destination,
+          rate: tla.payment.amount,
+          tlaId: tlaId,
+        }).catch(err => console.error('Failed to notify lessor:', err)),
 
-      // Create conversation now that TLA is fully signed
-      try {
-        const matchDoc = await getDoc(doc(firestore, `matches/${tla.matchId}`));
-        if (matchDoc.exists()) {
-          const matchData = matchDoc.data();
-          if (matchData.loadId && matchData.loadOwnerId) {
-            await createConversation(
-              firestore,
-              tla.lessor.ownerOperatorId,  // driver owner (lessor)
-              matchData.loadOwnerId,        // load owner (lessee)
-              matchData.loadId,
-              tlaId
-            );
-            console.log("✅ Conversation created for TLA:", tlaId);
-          }
+        notify.tlaSigned({
+          recipientEmail: tla.lessee.contactEmail,
+          recipientName: tla.lessee.legalName,
+          driverName: tla.driver.name,
+          loadOrigin: tla.trip.origin,
+          loadDestination: tla.trip.destination,
+          rate: tla.payment.amount,
+          tlaId: tlaId,
+        }).catch(err => console.error('Failed to notify lessee:', err)),
+      ]);
+
+      // Update match status and create conversation now that both have signed.
+      if (tla.matchId) {
+        try {
+          await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
+            status: 'tla_signed',
+          });
+        } catch (matchErr) {
+          console.warn("Could not update match status:", matchErr);
         }
-      } catch (convErr) {
-        // Non-fatal — log but don't block the sign flow
-        console.warn("Could not create conversation:", convErr);
+
+        // Create conversation now that TLA is fully signed
+        try {
+          const matchDoc = await getDoc(doc(firestore, `matches/${tla.matchId}`));
+          if (matchDoc.exists()) {
+            const matchData = matchDoc.data();
+            if (matchData.loadId && matchData.loadOwnerId) {
+              await createConversation(
+                firestore,
+                tla.lessor.ownerOperatorId,  // driver owner (lessor)
+                matchData.loadOwnerId,        // load owner (lessee)
+                matchData.loadId,
+                tlaId
+              );
+              console.log("✅ Conversation created for TLA:", tlaId);
+            }
+          }
+        } catch (convErr) {
+          // Non-fatal — log but don't block the sign flow
+          console.warn("Could not create conversation:", convErr);
+        }
       }
+    } else {
+      // Only one party has signed — notify the party who still needs to sign.
+      const pendingRole: 'lessor' | 'lessee' = role === 'lessor' ? 'lessee' : 'lessor';
+      const recipient = pendingRole === 'lessee' ? tla.lessee : tla.lessor;
+
+      notify.tlaReady({
+        recipientEmail: recipient.contactEmail,
+        recipientName: recipient.legalName,
+        role: pendingRole,
+        driverName: tla.driver.name,
+        loadOrigin: tla.trip.origin,
+        loadDestination: tla.trip.destination,
+        rate: tla.payment.amount,
+        tlaId: tlaId,
+      }).catch(err => console.error('Failed to send TLA ready notification:', err));
     }
-    
+
     showSuccess(
-      otherPartyHasSigned 
-        ? "TLA fully signed! Trip can now begin." 
+      bothSigned
+        ? "TLA fully signed! Trip can now begin."
         : `Signed! Waiting for ${role === 'lessor' ? 'lessee' : 'lessor'} to sign.`
     );
-    
+
     // Fetch and return updated TLA
     const updatedDoc = await getDoc(doc(firestore, `tlas/${tlaId}`));
     if (updatedDoc.exists()) {
       return { id: updatedDoc.id, ...updatedDoc.data() } as TLA;
     }
-    
+
     return null;
   } catch (error) {
     console.error("Error signing TLA:", error);
@@ -257,7 +240,7 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
 
   try {
     const now = new Date().toISOString();
-    
+
     const updateData = {
       status: 'in_progress',
       tripTracking: {
@@ -267,16 +250,16 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
       },
       updatedAt: now,
     };
-    
+
     await updateDoc(doc(firestore, `tlas/${tlaId}`), updateData);
-    
+
     // Update match status
     if (tla.matchId) {
       await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
         status: 'in_progress',
       }).catch(err => console.warn("Could not update match:", err));
     }
-    
+
     // Update driver availability
     try {
       const driverRef = doc(firestore, `owner_operators/${tla.lessor.ownerOperatorId}/drivers/${tla.driver.id}`);
@@ -284,7 +267,7 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
     } catch (err) {
       console.warn("Could not update driver availability:", err);
     }
-    
+
     // Send notifications
     await Promise.all([
       notify.tripStarted({
@@ -297,7 +280,7 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
         tlaId: tlaId,
         startedByName: userName,
       }).catch(err => console.error('Failed to notify lessor:', err)),
-      
+
       notify.tripStarted({
         recipientEmail: tla.lessee.contactEmail,
         recipientName: tla.lessee.legalName,
@@ -309,15 +292,15 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
         startedByName: userName,
       }).catch(err => console.error('Failed to notify lessee:', err)),
     ]);
-    
+
     showSuccess("Trip started! Both parties have been notified.");
-    
+
     // Fetch and return updated TLA
     const updatedDoc = await getDoc(doc(firestore, `tlas/${tlaId}`));
     if (updatedDoc.exists()) {
       return { id: updatedDoc.id, ...updatedDoc.data() } as TLA;
     }
-    
+
     return null;
   } catch (error) {
     console.error("Error starting trip:", error);
@@ -331,16 +314,16 @@ export async function startTrip(params: TripActionParams): Promise<TLA | null> {
  */
 export async function endTrip(params: TripActionParams): Promise<TLA | null> {
   const { firestore, tlaId, tla, userId, userName } = params;
-  
+
   if (!tla.tripTracking?.startedAt) {
     showError("Trip has not been started yet.");
     return null;
   }
-  
+
   try {
     const now = new Date().toISOString();
     const durationMinutes = calculateTripDuration(tla.tripTracking.startedAt, now);
-    
+
     const updateData = {
       status: 'completed',
       tripTracking: {
@@ -352,16 +335,16 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
       },
       updatedAt: now,
     };
-    
+
     await updateDoc(doc(firestore, `tlas/${tlaId}`), updateData);
-    
+
     // Update match status
     if (tla.matchId) {
       await updateDoc(doc(firestore, `matches/${tla.matchId}`), {
         status: 'completed',
       }).catch(err => console.warn("Could not update match:", err));
     }
-    
+
     // Update load status
     if (tla.matchId) {
       try {
@@ -379,9 +362,9 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
         console.warn("Could not update load status:", err);
       }
     }
-    
+
     const tripDurationStr = formatTripDuration(durationMinutes);
-    
+
     // Send notifications
     await Promise.all([
       notify.tripCompleted({
@@ -395,7 +378,7 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
         endedByName: userName,
         tripDuration: tripDurationStr,
       }).catch(err => console.error('Failed to notify lessor:', err)),
-      
+
       notify.tripCompleted({
         recipientEmail: tla.lessee.contactEmail,
         recipientName: tla.lessee.legalName,
@@ -408,13 +391,13 @@ export async function endTrip(params: TripActionParams): Promise<TLA | null> {
         tripDuration: tripDurationStr,
       }).catch(err => console.error('Failed to notify lessee:', err)),
     ]);
-    
+
     // Fetch and return updated TLA
     const updatedDoc = await getDoc(doc(firestore, `tlas/${tlaId}`));
     if (updatedDoc.exists()) {
       return { id: updatedDoc.id, ...updatedDoc.data() } as TLA;
     }
-    
+
     return null;
   } catch (error) {
     console.error("Error ending trip:", error);
@@ -433,8 +416,8 @@ export async function updateDriverAvailability(
 ): Promise<void> {
   try {
     const driverRef = doc(firestore, `owner_operators/${tla.lessor.ownerOperatorId}/drivers/${tla.driver.id}`);
-    await updateDoc(driverRef, { 
-      availability: markAvailable ? 'Available' : 'Off-duty' 
+    await updateDoc(driverRef, {
+      availability: markAvailable ? 'Available' : 'Off-duty'
     });
     showSuccess(
       `Trip completed! Driver marked as ${markAvailable ? 'Available' : 'Off-duty'}.`


### PR DESCRIPTION
## Summary
Closes 7 security/correctness gaps that are **still present on `qa`**. This replaces the earlier main-based branch (#203, now closed), which overlapped/conflicted with work `qa` already had (DEV-84, DEV-165). Each fix here was re-applied directly onto current `qa` so it merges cleanly.

## Changes
- **`notifications`** — require an authenticated caller. Was an open email relay (anyone could send mail from the app domain). All real callers fire from logged-in flows via same-origin fetch, so client behavior is unchanged.
- **`stripe/customer-portal`** & **`stripe/create-checkout-session`** — `await getAdminDb()`/`getAdminAuth()` before use. They returned Promises and threw at runtime; DEV-84 only fixed the webhook, so **these two were still broken on qa**.
- **`create-driver-account`** — validate the invitation server-side (exists + `pending` + not expired) and derive `ownerId` + email from the **invitation**, not the request body. Closes attaching a driver to any fleet, reusing a spent token, or registering a mismatched email. Invitation errors return 400.
- **`add-drivers-bulk`** — require the caller to be an actual owner-operator (profile must exist) so other accounts can't use it as an email cannon.
- **`fmcsa-debug`** — disabled in production builds unless `FMCSA_DEBUG_ENABLED=true` (stays available in local dev / opt-in QA).
- **`tla-actions` `signTLA`** — make signing race-safe with a Firestore transaction so the "has the other party signed?" decision uses fresh data (previously a stale page-load snapshot could strand a fully-signed TLA in `pending_*`). The DEV-154 attestation write, notifications, match-status update and conversation creation now run once after commit. DEV-81/DEV-84 trip-start guards untouched.

## Explicitly NOT included (already on qa)
- `stripe/refund` auth + `billing:refund` (DEV-165)
- `stripe/webhooks` idempotency + await fix (DEV-84) — qa's version is more complete; left as-is.

## Setup Required
- Optional: set `FMCSA_DEBUG_ENABLED=true` in any non-prod env where you want the FMCSA debug endpoint available.
- No new secrets / no Firestore rule changes (`tlas` rules already allow signed-in read/update).

## Test Plan
- [x] `tsc --noEmit`: 63 pre-existing errors, **0 new**.
- [x] `npm run build` passes.
- [ ] Signed-out `POST /api/notifications` → 401; in-app match/TLA emails still send.
- [ ] Stripe **test** mode: subscription checkout + customer portal now work (no 500s).
- [ ] Driver registration via a valid invite works; tampering with `ownerId`/email → 400; reusing a used token → 400.
- [ ] Non-owner account calling `add-drivers-bulk` → rejected; `fmcsa-debug` → 404 in prod without the flag.
- [ ] TLA: two browsers sign concurrently (lessor + lessee) → final status is `signed`, not stuck `pending_*`; e-sign attestation still recorded once; both fully-signed emails sent.

## Deferred (need a product decision — not in this PR)
- Admin role → Firebase custom claims (migration / lockout risk)
- Subscription-status enforcement (grace-period decision)
- Hazmat/endorsement hard-filter in matching (which quals are exclusionary + missing-data handling)

https://claude.ai/code/session_013vvYfAbxCM1R7wvaiJ97re

---
_Generated by [Claude Code](https://claude.ai/code/session_013vvYfAbxCM1R7wvaiJ97re)_